### PR TITLE
Remove duplicate "Total" entry in graph tooltips

### DIFF
--- a/data/interfaces/default/graphs.html
+++ b/data/interfaces/default/graphs.html
@@ -760,6 +760,7 @@
                     if (this.points.length > 1) {
                         var total = 0;
                         $.each(this.points, function(i, point) {
+                            if (point.series.name === 'Total') return;
                             s += '<br/>'+point.series.name+': '+point.y;
                             total += point.y;
                         });
@@ -786,6 +787,7 @@
                     if (this.points.length > 1) {
                         var total = 0;
                         $.each(this.points, function(i, point) {
+                            if (point.series.name === 'Total') return;
                             s += '<br/>'+point.series.name+': '+moment.duration(point.y, 'hours').format('D [days] H [hrs] m [mins]');
                             total += point.y;
                         });


### PR DESCRIPTION
## Description

Since adding the "Total" curve in #2497, there are two "Total" entries in the tooltips, because the "Total" curve isn't ignored while computing the total. This fixes that.

### Screenshot

Include screenshots if the changes are UI-related.

Before:

![image](https://github.com/user-attachments/assets/79e094ca-dd71-471d-9356-890935b3da88)

After:

![image](https://github.com/user-attachments/assets/e274a16d-081f-4ba7-a6a7-c4f3119f32f4)


### Issues Fixed or Closed

No issue was opened.

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods
