### PR TITLE
Feature: Adding Docker Compose File for setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ Read the [Installation Guides][Installation] for instructions on how to install 
 [badge-installer-beta-ci]: https://img.shields.io/github/actions/workflow/status/Tautulli/Tautulli/.github/workflows/publish-installers.yml?style=flat-square&branch=beta
 [badge-installer-nightly-ci]: https://img.shields.io/github/actions/workflow/status/Tautulli/Tautulli/.github/workflows/publish-installers.yml?style=flat-square&branch=nightly
 
+
+### Local Build Using Docker Compose
+
+You can build and run Tautulli using the provided `docker-compose.yml` file. Follow these steps:
+
+1. Ensure you have [Docker](https://www.docker.com/) and [Docker Compose](https://docs.docker.com/compose/) installed on your system.
+2. Clone the repository:
+   ```bash
+   git clone https://github.com/Tautulli/Tautulli.git
+   cd Tautulli
+   ```
+3. Run the following command to start the application:
+   ```bash
+   docker-compose up -d
+   ```
+4. Access Tautulli in your browser at `http://localhost:8181`.
+
+For more details, refer to the [Docker Compose documentation](https://docs.docker.com/compose/).
+
 ## Support
 
 [![Wiki][badge-wiki]][Wiki]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.8'
+
+services:
+  tautulli:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: tautulli
+    ports:
+      - "8181:8181" # Map the Tautulli web interface to localhost:8181
+    volumes:
+      - ./config:/config # Persistent configuration storage
+      - ./logs:/logs     # Persistent log storage
+    restart: unless-stopped


### PR DESCRIPTION
## Description

Added a `docker-compose.yml` file to simplify container orchestration for the project. This allows users to:
- Build and run the existing Docker image with a single command
- Manage container lifecycle more easily
- Standardize the deployment configuration

### Screenshot

N/A (Not a UI change)

### Issues Fixed or Closed

- N/A (New feature addition)

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods

## Additional Notes

The docker-compose file maintains compatibility with the existing Docker setup while providing:
- Simplified startup with `docker-compose up`
- Standardized port mapping
- Easy configuration of environment variables if needed