### PR TITLE
Fix race condition in image cache directory creation

### DIFF
--- a/plexpy/webserve.py
+++ b/plexpy/webserve.py
@@ -4801,7 +4801,7 @@ class WebInterface(object):
         ffp = os.path.join(c_dir, fp)
 
         if not os.path.exists(c_dir):
-            os.mkdir(c_dir)
+            os.makedirs(c_dir, exist_ok=True)
 
         clip = helpers.bool_true(clip)
 


### PR DESCRIPTION
## Summary
Fix a race condition that occurs when multiple threads try to create the image cache directory simultaneously.

## Problem
The current code uses `os.mkdir()` which throws a `FileExistsError` when multiple threads check if the directory exists and then try to create it at the same time:

```
FileExistsError: [Errno 17] File exists: '/config/cache/images'
```

This happens in the `real_pms_image_proxy` function in `plexpy/webserve.py:4804`.

## Solution
Replace `os.mkdir(c_dir)` with `os.makedirs(c_dir, exist_ok=True)` which:
- Handles race conditions gracefully by not raising an error if the directory already exists
- Is the standard Python solution for this exact scenario
- Maintains the same functionality while being thread-safe

## Test plan
- [x] Verified the syntax works correctly with Python 3
- [x] Confirmed the fix resolves the race condition in multi-threaded environments
- [x] Tested locally - no more FileExistsError exceptions