### PR TITLE
SyntaxWarning: invalid escape sequence

### DIFF
--- a/lib/facebook/__init__.py
+++ b/lib/facebook/__init__.py
@@ -96,7 +96,7 @@ class GraphAPI(object):
         self.session = session or requests.Session()
 
         if version:
-            version_regex = re.compile("^\d\.\d{1,2}$")
+            version_regex = re.compile(r"^\d\.\d{1,2}$")
             match = version_regex.search(str(version))
             if match is not None:
                 if str(version) not in VALID_API_VERSIONS:

--- a/lib/gntp/core.py
+++ b/lib/gntp/core.py
@@ -19,18 +19,18 @@ __all__ = [
 
 #GNTP/<version> <messagetype> <encryptionAlgorithmID>[:<ivValue>][ <keyHashAlgorithmID>:<keyHash>.<salt>]
 GNTP_INFO_LINE = re.compile(
-	'GNTP/(?P<version>\d+\.\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\-OK|\-ERROR)' +
-	' (?P<encryptionAlgorithmID>[A-Z0-9]+(:(?P<ivValue>[A-F0-9]+))?) ?' +
-	'((?P<keyHashAlgorithmID>[A-Z0-9]+):(?P<keyHash>[A-F0-9]+).(?P<salt>[A-F0-9]+))?\r\n',
+	r'GNTP/(?P<version>\d+\.\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\-OK|\-ERROR)' +
+	r' (?P<encryptionAlgorithmID>[A-Z0-9]+(:(?P<ivValue>[A-F0-9]+))?) ?' +
+	r'((?P<keyHashAlgorithmID>[A-Z0-9]+):(?P<keyHash>[A-F0-9]+).(?P<salt>[A-F0-9]+))?\r\n',
 	re.IGNORECASE
 )
 
 GNTP_INFO_LINE_SHORT = re.compile(
-	'GNTP/(?P<version>\d+\.\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\-OK|\-ERROR)',
+	r'GNTP/(?P<version>\d+\.\d+) (?P<messagetype>REGISTER|NOTIFY|SUBSCRIBE|\-OK|\-ERROR)',
 	re.IGNORECASE
 )
 
-GNTP_HEADER = re.compile('([\w-]+):(.+)')
+GNTP_HEADER = re.compile(r'([\w-]+):(.+)')
 
 GNTP_EOL = gntp.shim.b('\r\n')
 GNTP_SEP = gntp.shim.b(': ')


### PR DESCRIPTION
## Description

Since v3.12 Python complains about invalid escape sequences (e.g. `\d`). This gets rid of the 4 cases I found in my logs (there're probably more).
My suggestion would be to **always** do raw-strings when dealing with regex (I basically treat it like the`r` stands for regex). 

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
