### PR TITLE
Persist table column and sort settings across browser sessions

### DIFF
--- a/data/interfaces/default/js/tables/collections_table.js
+++ b/data/interfaces/default/js/tables/collections_table.js
@@ -15,7 +15,7 @@ collections_table_options = {
         data.search.search = "";
         data.start = 0;
     },
-    "stateDuration": 0,
+    "stateDuration": -1,
     "processing": false,
     "serverSide": true,
     "pageLength": 25,

--- a/data/interfaces/default/js/tables/export_table.js
+++ b/data/interfaces/default/js/tables/export_table.js
@@ -27,7 +27,7 @@ export_table_options = {
         data.search.search = "";
         data.start = 0;
     },
-    "stateDuration": 0,
+    "stateDuration": -1,
     "processing": false,
     "serverSide": true,
     "pageLength": 25,

--- a/data/interfaces/default/js/tables/history_table.js
+++ b/data/interfaces/default/js/tables/history_table.js
@@ -28,7 +28,7 @@ history_table_options = {
         data.search.search = "";
         data.start = 0;
     },
-    "stateDuration": 0,
+    "stateDuration": -1,
     "processing": false,
     "serverSide": true,
     "pageLength": 25,

--- a/data/interfaces/default/js/tables/libraries.js
+++ b/data/interfaces/default/js/tables/libraries.js
@@ -21,7 +21,7 @@ libraries_list_table_options = {
         data.search.search = "";
         data.start = 0;
     },
-    "stateDuration": 0,
+    "stateDuration": -1,
     "pagingType": "full_numbers",
     "autoWidth": false,
     "scrollX": true,

--- a/data/interfaces/default/js/tables/login_logs.js
+++ b/data/interfaces/default/js/tables/login_logs.js
@@ -14,7 +14,7 @@ login_log_table_options = {
         data.search.search = "";
         data.start = 0;
     },
-    "stateDuration": 0,
+    "stateDuration": -1,
     "pagingType": "full_numbers",
     "processing": false,
     "serverSide": true,

--- a/data/interfaces/default/js/tables/logs.js
+++ b/data/interfaces/default/js/tables/logs.js
@@ -10,7 +10,7 @@ var log_table_options = {
         data.search.search = "";
         data.start = 0;
     },
-    "stateDuration": 0,
+    "stateDuration": -1,
     "language": {
                 "search": "Search: ",
                 "lengthMenu": "Show _MENU_ lines per page",

--- a/data/interfaces/default/js/tables/media_info_table.js
+++ b/data/interfaces/default/js/tables/media_info_table.js
@@ -29,7 +29,7 @@ media_info_table_options = {
         data.search.search = "";
         data.start = 0;
     },
-    "stateDuration": 0,
+    "stateDuration": -1,
     "processing": false,
     "serverSide": true,
     "pageLength": 25,

--- a/data/interfaces/default/js/tables/newsletter_logs.js
+++ b/data/interfaces/default/js/tables/newsletter_logs.js
@@ -10,7 +10,7 @@ newsletter_log_table_options = {
         data.search.search = "";
         data.start = 0;
     },
-    "stateDuration": 0,
+    "stateDuration": -1,
     "language": {
                 "search":"Search: ",
                 "lengthMenu": "Show _MENU_ lines per page",

--- a/data/interfaces/default/js/tables/notification_logs.js
+++ b/data/interfaces/default/js/tables/notification_logs.js
@@ -10,7 +10,7 @@ notification_log_table_options = {
         data.search.search = "";
         data.start = 0;
     },
-    "stateDuration": 0,
+    "stateDuration": -1,
     "language": {
                 "search":"Search: ",
                 "lengthMenu": "Show _MENU_ lines per page",

--- a/data/interfaces/default/js/tables/playlists_table.js
+++ b/data/interfaces/default/js/tables/playlists_table.js
@@ -15,7 +15,7 @@ playlists_table_options = {
         data.search.search = "";
         data.start = 0;
     },
-    "stateDuration": 0,
+    "stateDuration": -1,
     "processing": false,
     "serverSide": true,
     "pageLength": 25,

--- a/data/interfaces/default/js/tables/plex_logs.js
+++ b/data/interfaces/default/js/tables/plex_logs.js
@@ -10,7 +10,7 @@ var plex_log_table_options = {
         data.search.search = "";
         data.start = 0;
     },
-    "stateDuration": 0,
+    "stateDuration": -1,
     "language": {
                 "search": "Search: ",
                 "lengthMenu": "Show _MENU_ lines per page",

--- a/data/interfaces/default/js/tables/sync_table.js
+++ b/data/interfaces/default/js/tables/sync_table.js
@@ -11,7 +11,7 @@ sync_table_options = {
         data.search.search = "";
         data.start = 0;
     },
-    "stateDuration": 0,
+    "stateDuration": -1,
     "language": {
         "search": "Search: ",
         "lengthMenu": "Show _MENU_ lines per page",

--- a/data/interfaces/default/js/tables/user_ips.js
+++ b/data/interfaces/default/js/tables/user_ips.js
@@ -36,7 +36,7 @@ user_ip_table_options = {
         data.search.search = "";
         data.start = 0;
     },
-    "stateDuration": 0,
+    "stateDuration": -1,
     "pagingType": "full_numbers",
     "processing": false,
     "serverSide": true,

--- a/data/interfaces/default/js/tables/users.js
+++ b/data/interfaces/default/js/tables/users.js
@@ -38,7 +38,7 @@ users_list_table_options = {
         data.search.search = "";
         data.start = 0;
     },
-    "stateDuration": 0,
+    "stateDuration": -1,
     "pagingType": "full_numbers",
     "autoWidth": false,
     "scrollX": true,


### PR DESCRIPTION
## Summary
- Change `stateDuration` from `0` (sessionStorage) to `-1` (localStorage) for all DataTables
- Column visibility, sort order, and page length preferences now persist permanently across browser sessions
- Previously, settings were cleared when the browser was closed

## Context
The original commit `4ef36a46` from 2018 had the message "Set datatables save state duration to indefinitely" but used `0` which, per DataTables documentation, means sessionStorage (session only). This fix uses `-1` which actually implements the original intent:

- `0` = sessionStorage (cleared on browser close)
- `-1` = localStorage (truly indefinite)

## Affected Tables
- History
- Collections
- Users
- Libraries
- Logs
- Plex Logs
- Notification Logs
- Newsletter Logs
- Login Logs
- Export
- Playlists
- Sync
- User IPs
- Media Info

## Test Plan
- [ ] Open any table page (e.g., History)
- [ ] Change column visibility using "Select columns" button
- [ ] Change sort order
- [ ] Close browser completely
- [ ] Reopen and verify settings are preserved