### PR TITLE
fix: replace newlines with Markdown hard line breaks in Gotify messages

### DIFF
--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -1717,7 +1717,7 @@ class GOTIFY(Notifier):
                     'contentType': 'text/markdown'
                 }
             },
-            'message': body,
+            'message': body.replace('\n', '  \n'),
             'priority': self.config['priority']
         }
 


### PR DESCRIPTION
## Summary

Fixes #2702 — single line breaks in Gotify notification text were being collapsed into spaces.

**Root cause:** The Gotify notification agent hardcodes `contentType: text/markdown` (required to support poster images). In Markdown, a single `\n` is not a hard line break — it renders as a space. So notification text entered with simple Enter key presses would arrive as a single run-on line.

**Fix:** Replace `\n` with `  \n` (two trailing spaces + newline) in the message body before sending. This is the correct Markdown syntax for a hard line break, as suggested in the issue. `text/markdown` is kept so poster images continue to work.

## Change

`plexpy/notifiers.py` — one line in `GOTIFY.agent_notify()`:

```python
# before
'message': body,

# after
'message': body.replace('\n', '  \n'),
```

## Test plan

- [ ] Set up a Gotify notification agent in Tautulli
- [ ] Enter a message body with single line breaks (Enter key)
- [ ] Send a test notification and confirm line breaks render correctly in Gotify
- [ ] Confirm poster images still render when "Include Poster Image" is enabled