### PR TITLE
Fix duplicate activity progress timers

### DIFF
--- a/data/interfaces/default/index.html
+++ b/data/interfaces/default/index.html
@@ -295,6 +295,8 @@
 
     var create_instances = [];
     var activity_ready = true;
+    var activity_refresh_timer;
+    var activity_progress_timer;
 
     $('#currentActivityHeader-bandwidth-tooltip').tooltip({ container: 'body', placement: 'right', delay: 50 });
 
@@ -657,14 +659,17 @@
     }
 
     function activityConnected() {
+        clearInterval(activity_refresh_timer);
+        clearInterval(activity_progress_timer);
+
         getCurrentActivity();
-        setInterval(function () {
+        activity_refresh_timer = setInterval(function () {
             if (!(create_instances.length) && activity_ready) {
                 getCurrentActivity();
             }
         }, ${config['home_refresh_interval'] * 1000});
 
-        setInterval(function(){
+        activity_progress_timer = setInterval(function(){
             $('.progress_time_offset').each(function () {
                 if ($(this).data('state') === 'playing' && $(this).data('view_offset') >= 0) {
                     var view_offset = parseInt($(this).data('view_offset'));


### PR DESCRIPTION
## Description

Fixes duplicate homepage Activity timers by clearing any existing activity refresh and progress ticker intervals before starting new ones.

`activityConnected()` starts two timers each time it runs: the Activity API refresh timer and the 1-second playback progress ticker. If `activityConnected()` is invoked more than once in the same page lifecycle, the progress ticker can stack. That makes Activity card playback positions advance faster than real time, then snap backwards when the next Activity API refresh corrects the displayed position.

This stores both interval IDs in higher-scope activity timer variables and clears any existing timers before creating new ones.

### Screenshot

N/A. This is a timer behavior fix. I reproduced the issue on a Docker Tautulli instance where Activity progress advanced about 2 seconds per second and snapped backwards, then confirmed the Activity progress behaved normally after applying this change locally.

### Issues Fixed or Closed

N/A. No issue was opened before this PR.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods

No comments or docstrings were added because this is a small JavaScript timer guard and no methods were added or changed.

Validation: `git diff --check`.