### PR TITLE
Default HTTP_HOST to empty string for native dual-stack networking

### DIFF
--- a/Tautulli.py
+++ b/Tautulli.py
@@ -284,8 +284,9 @@ def main():
 
     # Open webbrowser
     if plexpy.CONFIG.LAUNCH_BROWSER and not args.nolaunch and not plexpy.DEV:
-        plexpy.launch_browser(plexpy.CONFIG.HTTP_HOST, plexpy.HTTP_PORT,
-                              plexpy.HTTP_ROOT)
+        # Fallback to localhost if host is empty string
+        host = plexpy.CONFIG.HTTP_HOST if plexpy.CONFIG.HTTP_HOST else 'localhost'
+        plexpy.launch_browser(host, plexpy.HTTP_PORT, plexpy.HTTP_ROOT)
 
     if common.PLATFORM == 'Darwin' and plexpy.CONFIG.SYS_TRAY_ICON:
         if not macos.HAS_PYOBJC:

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -126,7 +126,7 @@ _CONFIG_DEFINITIONS = {
     'HTTP_ENVIRONMENT': (str, 'General', 'production'),
     'HTTP_HASH_PASSWORD': (int, 'General', 1),
     'HTTP_HASHED_PASSWORD': (int, 'General', 1),
-    'HTTP_HOST': (str, 'General', '0.0.0.0'),
+    'HTTP_HOST': (str, 'General', ''),
     'HTTP_PASSWORD': (str, 'General', ''),
     'HTTP_PORT': (int, 'General', 8181),
     'HTTP_PROXY': (int, 'General', 0),


### PR DESCRIPTION
## Description

This PR introduces native dual-stack (IPv4 & IPv6) support by default for Tautulli, ensuring an out-of-the-box wildcard listening experience for modern containerized setups (like rootless Podman) and IPv6-first home environments.

1. **plexpy/config.py**: Changed the default fallback value for `HTTP_HOST` from `'0.0.0.0'` to an empty string `''`. This instructs CherryPy to initialize wildcard listeners across both network adapters simultaneously.
2. **Tautulli.py**: Updated the browser auto-launcher check so that if `HTTP_HOST` evaluates to an empty string, it gracefully falls back to using `'localhost'` instead of trying to pass an empty host string to the browser wrapper.

### Screenshot

*N/A - This is a backend networking and CLI utility change.*

### Issues Fixed or Closed

- None explicitly filed, but closes local container deployment dual-stack bottlenecks.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
