### PR TITLE
Fix on_created KeyError when item metadata is unavailable

### DIFF
--- a/plexpy/activity_handler.py
+++ b/plexpy/activity_handler.py
@@ -693,10 +693,10 @@ def on_created(rating_key, **kwargs):
     pms_connect = pmsconnect.PmsConnect()
     metadata = pms_connect.get_metadata_details(rating_key)
 
-    logger.debug("Tautulli TimelineHandler :: Library item '%s' (%s) added to Plex.",
-                 metadata['full_title'], str(rating_key))
-
     if metadata:
+        logger.debug("Tautulli TimelineHandler :: Library item '%s' (%s) added to Plex.",
+                     metadata['full_title'], str(rating_key))
+
         notify = True
         # now = helpers.timestamp()
         #


### PR DESCRIPTION
## Description

`pmsconnect.get_metadata_details()` returns an empty dict when metadata can't be retrieved (item removed between the Plex `created` timeline event and Tautulli's lookup, an empty MediaContainer, or an XML parse error). `on_created` logged `metadata['full_title']` before the `if metadata:` guard, so an empty result raised `KeyError: 'full_title'` and crashed the recently-added notification callback — leaving the existing `else` "Unable to retrieve metadata" branch unreachable. This moves the debug log inside the `if metadata:` block so the empty case is handled gracefully by the existing error branch. Regression traced to commit 897f4156 (2021).

### Issues Fixed or Closed

N/A — found during code review; not tied to a filed issue.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods

---
Disclosure: this fix was prepared with AI assistance (Claude). The regression was traced to commit 897f4156; the empty-dict return paths are in pmsconnect.py (get_metadata_details, lines ~717/723/728). Verified with a reproduction of the exact logic (empty dict → KeyError before, graceful else after) plus py_compile; no project test suite exists.
