### PR TITLE
Compute datatables filtered count using a window function

### DIFF
--- a/plexpy/datatables.py
+++ b/plexpy/datatables.py
@@ -14,11 +14,15 @@
 #  along with Tautulli.  If not, see <http://www.gnu.org/licenses/>.
 
 import re
+import sqlite3
 
 import plexpy
 from plexpy import database
 from plexpy import helpers
 from plexpy import logger
+
+# Window functions require SQLite 3.25.0
+_WINDOW_FUNCTIONS = sqlite3.sqlite_version_info >= (3, 25, 0)
 
 
 class DataTables(object):
@@ -104,11 +108,6 @@ class DataTables(object):
         inner_query = 'SELECT %s FROM %s %s %s %s %s' \
                       % (extracted_columns['column_string'], table_name, join, c_where, group, union)
 
-        # Get the number of filtered rows
-        filtered_count = self.ssp_db.select(
-            'SELECT COUNT(*) AS filtered_count FROM (%s) %s' % (inner_query, where),
-            args=args)[0]['filtered_count']
-
         # Paginate using LIMIT and OFFSET so only the requested page is
         # fetched from the database (LIMIT -1 returns all rows in SQLite)
         start = helpers.cast_to_int(parameters.get('start', 0))
@@ -116,13 +115,32 @@ class DataTables(object):
         if length < 0:
             length = -1
 
-        # Build the query
-        query = 'SELECT * FROM (%s) %s %s LIMIT ? OFFSET ?' % (inner_query, where, order)
+        # Build the query, computing the number of filtered rows with a
+        # window function so the inner query only runs once
+        filtered_count = None
+
+        if _WINDOW_FUNCTIONS:
+            query = 'SELECT *, COUNT(*) OVER () AS filtered_count FROM (%s) %s %s LIMIT ? OFFSET ?' \
+                    % (inner_query, where, order)
+        else:
+            query = 'SELECT * FROM (%s) %s %s LIMIT ? OFFSET ?' % (inner_query, where, order)
 
         # logger.debug("Query: %s" % query)
 
         # Execute the query
         result = self.ssp_db.select(query, args=args + [length, start])
+
+        if _WINDOW_FUNCTIONS and result:
+            filtered_count = result[0]['filtered_count']
+            for row in result:
+                del row['filtered_count']
+
+        if filtered_count is None:
+            # Query the filtered count separately if it could not be
+            # computed with a window function or no rows were returned
+            filtered_count = self.ssp_db.select(
+                'SELECT COUNT(*) AS filtered_count FROM (%s) %s' % (inner_query, where),
+                args=args)[0]['filtered_count']
 
         # Remove NULL rows
         result = [row for row in result if not all(v is None for v in row.values())]


### PR DESCRIPTION
## Description

__AI was used (Claude Fable) to create this PR. I'm a Front End developer by trade, but wanted to follow up on my previous PR.__

This is a follow-up to my previous PR #2728, which moved datatables pagination into SQL. After that merged into nightly, I tested on my Unraid box and noticed it was actually _slower_ than `master`.

The query in #2728 ran great on my Mac's SSD (and was cached on repeated visits), but on Unraid's slower IO it ran worse than before the optimization. Troubleshooting the SSD vs Unraid issue, it seems the double inner query is worse for IO.

This PR folds the filtered row count into the page query using a `COUNT(*) OVER ()` window function so the inner query only executes once. I also call this out below, but window functions require SQLite ≥ 3.25.0 (September 2018). I added a check so older SQLite versions fall back to the existing two-query behavior from #2728 so nothing breaks.

## Changes

- `DataTables.ssp_query` no longer issues a separate `SELECT COUNT(*) FROM (inner_query)` before fetching the page; the page query now selects `COUNT(*) OVER () AS filtered_count` alongside the row columns, computing the filtered count in the same pass.
- The `filtered_count` column is stripped from each result row before rows are returned, so downstream consumers see the same row shape as before.
- A module-level `_WINDOW_FUNCTIONS` check (`sqlite3.sqlite_version_info >= (3, 25, 0)`) gates the window function; older SQLite uses the previous separate COUNT query.
- If the page query returns no rows (offset past the end of the results, or a count-only request with `length=0`), the filtered count is queried separately so `recordsFiltered` is always accurate. This also fixes an edge case where an API call with `length=0` would have reported a filtered count of 0.

## Callout

- This is the first window function in the codebase, which is why there's a version guard. Happy to drop the fallback if you'd rather just require 3.25.0 (or close this PR if you don't want to require that version of SQL - in that case, it might make more sense to revert my "optimization" from the last PR).
- I verified against my full actual database again (33k rows), but again was only able to test on my Mac since I have no way of currently deploying to the Unraid machine. The tests I ran locally beat all the timings against nightly and master. I also verified both the window and fallback paths return identical rows and counts across normal pages, partial last pages, `length=-1`, `length=0`, past-the-end offsets, and zero-match filters.
- The one intentionally slower path is an empty page result (falls back to two passes); DataTables clients don't request nonexistent pages in normal operation, so this path is effectively never hit.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
