### PR TITLE
firefox count clipping on watch statistics

### DIFF
--- a/data/interfaces/default/css/tautulli.css
+++ b/data/interfaces/default/css/tautulli.css
@@ -1464,7 +1464,7 @@ a .dashboard-activity-metadata-user-thumb:hover {
     flex-wrap: nowrap;
     align-items: baseline;
     width: 100%;
-    padding: 2.5px 5px;
+    padding: 2.5px 8px 2.5px 5px;
     line-height: 14px;
     border-bottom: 1px solid rgba(255,255,255,0.05);
     cursor: default;
@@ -1491,6 +1491,7 @@ a .dashboard-activity-metadata-user-thumb:hover {
     text-overflow: ellipsis;
     -webkit-flex-grow: 1;
     flex-grow: 1;
+    min-width: 0;
 }
 .dashboard-stats-info-item .sub-count {
     height: 100%;
@@ -1499,7 +1500,6 @@ a .dashboard-activity-metadata-user-thumb:hover {
     font-size: 12px;
     text-align: right;
     white-space: nowrap;
-    overflow: hidden;
     -webkit-flex-shrink: 0;
     flex-shrink: 0;
 }
@@ -1514,7 +1514,7 @@ a .dashboard-activity-metadata-user-thumb:hover {
     flex-shrink: 0;
 }
 .dashboard-stats-info-item.expanded {
-    padding: 5px 5px;
+    padding: 5px 8px 5px 5px;
     line-height: 20px;
 }
 .dashboard-stats-info-item.expanded .sub-heading {


### PR DESCRIPTION
## Summary
- Fix Firefox-only clipping of play/count numbers in Watch Statistics and Library Statistics dashboard widgets
- Add `min-width: 0` to the title column so long titles ellipsize instead of pushing counts off-screen
- Remove `overflow: hidden` from the count column and add a small right padding buffer on stat rows

## Test plan
- [ ] Open the Tautulli home page in Firefox and confirm play/user/stream counts are fully visible in all Watch Statistics cards
- [ ] Confirm long titles still ellipsize with `...` instead of clipping counts
- [ ] Verify no visual regression in Chrome/Edge
- [ ] Toggle between Plays and duration modes to confirm longer time strings are not clipped
- [ ] Spot-check Library Statistics cards if enabled on the home page