### PR TITLE
Require matching guid when grouping non-live history

### DIFF
--- a/plexpy/activity_processor.py
+++ b/plexpy/activity_processor.py
@@ -484,6 +484,7 @@ class ActivityProcessor(object):
     def group_history(self, last_id, session, metadata=None):
         new_session = prev_session = None
         prev_watched = None
+        session_guid = metadata['guid'] if metadata else session.get('guid')
 
         db = database.MonitorDatabase()
 
@@ -512,9 +513,15 @@ class ActivityProcessor(object):
                 prev_watched = False
 
         else:
-            # Check if we should group the session, select the last two rows from the user
-            query = "SELECT id, rating_key, view_offset, reference_id FROM session_history " \
-                    "WHERE id <= ? AND user_id = ? AND rating_key = ? ORDER BY id DESC LIMIT 2 "
+            # Check if we should group the session, select the last two rows from the user.
+            # For non-live media, also compare guid so regrouping won't merge unrelated
+            # history rows that happen to share a stale rating_key.
+            query = "SELECT session_history.id, session_history.rating_key, session_history.view_offset, " \
+                    "session_history.reference_id, session_history_metadata.guid " \
+                    "FROM session_history " \
+                    "LEFT OUTER JOIN session_history_metadata ON session_history.id == session_history_metadata.id " \
+                    "WHERE session_history.id <= ? AND session_history.user_id = ? " \
+                    "AND session_history.rating_key = ? ORDER BY session_history.id DESC LIMIT 2 "
 
             args = [last_id, session['user_id'], session['rating_key']]
 
@@ -524,11 +531,13 @@ class ActivityProcessor(object):
                 new_session = {'id': result[0]['id'],
                                'rating_key': result[0]['rating_key'],
                                'view_offset': helpers.cast_to_int(result[0]['view_offset']),
+                               'guid': session_guid,
                                'reference_id': result[0]['reference_id']}
 
                 prev_session = {'id': result[1]['id'],
                                 'rating_key': result[1]['rating_key'],
                                 'view_offset': helpers.cast_to_int(result[1]['view_offset']),
+                                'guid': result[1]['guid'],
                                 'reference_id': result[1]['reference_id']}
 
                 if metadata:
@@ -549,7 +558,9 @@ class ActivityProcessor(object):
         # then set the reference_id to the previous row,
         # else set the reference_id to the new id
         if prev_watched is False and (
-            not session['live'] and prev_session['view_offset'] <= new_session['view_offset'] or 
+            not session['live'] and prev_session['guid'] and new_session['guid'] and
+            prev_session['guid'] == new_session['guid'] and
+            prev_session['view_offset'] <= new_session['view_offset'] or
             session['live'] and prev_session['guid'] == new_session['guid']
         ):
             if metadata:


### PR DESCRIPTION
## Summary
- require matching `guid` when grouping non-live history rows
- keep the existing live-TV grouping behavior unchanged
- prevent `regroup_history()` from re-merging unrelated items when legacy `rating_key` collisions exist

## Problem
`regroup_history()` currently replays `group_history()` across all stored history rows. For non-live media, `group_history()` groups by `user_id + rating_key` and reuses the previous row's `reference_id`.

On long-lived databases that have survived Plex/library migrations, historical `rating_key` collisions can exist across different media items. When that happens, regrouping can merge unrelated plays back together even after `reference_id` has been repaired.

Verified example from my database:
- `Modern Family - Wine Weekend`
- `NCIS: Origins - Operazione Tramonto`
- both stored with `rating_key = 8908`
- different `guid` values
- `Regroup play history` merged them again because the current logic trusted `rating_key`

## Fix
For non-live media, this patch still narrows candidates by `user_id + rating_key`, but only reuses the previous `reference_id` when the previous row and current row also share the same `guid`.

That keeps normal resume/regroup behavior for the same item while avoiding false merges caused by stale `rating_key` collisions in legacy history.

## Validation
- syntax check with `py_compile`
- verified against the failing `rating_key = 8908` case from my backup DB
- with this patch, the bad pair no longer qualifies for regroup because the `guid` values differ
