### PR TITLE
Tautulli Remote Relay Support

### DIFF
--- a/data/interfaces/default/mobile_device_config.html
+++ b/data/interfaces/default/mobile_device_config.html
@@ -44,18 +44,18 @@
                                 <p class="help-block">Your app device token.</p>
                             </div>
                             <div class="form-group">
-                                <label for="push_token">Push Token</label>
+                                <label for="relay_device_id">Notification Device ID</label>
                                 <div class="row">
                                     <div class="col-md-12">
                                         <div class="input-group">
                                             <span class="input-group-btn">
                                                 <button class="btn btn-form reveal-token" type="button"><i class="fa fa-eye-slash"></i></button>
                                             </span>
-                                            <input type="password" class="form-control" id="push_token" value="${device['push_token'] or device['onesignal_id'] or ''}" size="30" readonly>
+                                            <input type="password" class="form-control" id="relay_device_id" value="${device['relay_device_id'] or device['onesignal_id'] or ''}" size="30" readonly>
                                         </div>
                                     </div>
                                 </div>
-                                <p class="help-block">Your device token for notifications.</p>
+                                <p class="help-block">Your device ID for notifications.</p>
                             </div>
                         </div>
                     </div>

--- a/data/interfaces/default/mobile_device_config.html
+++ b/data/interfaces/default/mobile_device_config.html
@@ -44,18 +44,18 @@
                                 <p class="help-block">Your app device token.</p>
                             </div>
                             <div class="form-group">
-                                <label for="friendly_name">OneSignal Device ID</label>
+                                <label for="push_token">Push Token</label>
                                 <div class="row">
                                     <div class="col-md-12">
                                         <div class="input-group">
                                             <span class="input-group-btn">
                                                 <button class="btn btn-form reveal-token" type="button"><i class="fa fa-eye-slash"></i></button>
                                             </span>
-                                            <input type="password" class="form-control" id="onesignal_id" value="${device['onesignal_id'] or ''}" size="30" readonly>
+                                            <input type="password" class="form-control" id="push_token" value="${device['push_token'] or device['onesignal_id'] or ''}" size="30" readonly>
                                         </div>
                                     </div>
                                 </div>
-                                <p class="help-block">Your OneSignal device ID for notifications.</p>
+                                <p class="help-block">Your device token for notifications.</p>
                             </div>
                         </div>
                     </div>

--- a/data/interfaces/default/mobile_devices_table.html
+++ b/data/interfaces/default/mobile_devices_table.html
@@ -14,7 +14,7 @@ DOCUMENTATION :: END
     <li class="mobile-device pointer" data-id="${device['id']}" data-name="${device['device_name']}">
         <span>
             % if device['official'] == -1:
-                <span class="toggle-left official-tooltip" data-toggle="tooltip" data-placement="top" title="OneSignal Validation Failed"><i class="fa fa-lg fa-fw fa-exclamation-triangle"></i></span>
+                <span class="toggle-left official-tooltip" data-toggle="tooltip" data-placement="top" title="Notification Registration Validation Failed"><i class="fa fa-lg fa-fw fa-exclamation-triangle"></i></span>
             % elif device['official'] > 0:
                 <%
                     icon = 'mobile'

--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -2091,7 +2091,7 @@ Rating: {rating}/10   --> Rating: /10
                     or manually enter the connection info and device token into the app settings. This window will automatically close once device registration is successful.
                 </p>
                 <p class="help-block">
-                    Note: relay.tautulliremote.com must not be blocked (e.g. in Pi-hole) for device registration.
+                    Note: Tautulli must be able to reach relay.tautulliremote.com (e.g. not blocked in Pi-hole) to validate the device and deliver notifications.
                 </p>
                 <label>QR Code</label>
                 <div id="api_qr_code"></div>

--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -2091,7 +2091,7 @@ Rating: {rating}/10   --> Rating: /10
                     or manually enter the connection info and device token into the app settings. This window will automatically close once device registration is successful.
                 </p>
                 <p class="help-block">
-                    Note: The Tautulli push relay (and OneSignal.com, for app versions before the relay) must not be blocked (e.g. in Pi-hole) for device registration.
+                    Note: The Tautulli Remote relay (and OneSignal.com, for app versions before the relay) must not be blocked (e.g. in Pi-hole) for device registration.
                 </p>
                 <label>QR Code</label>
                 <div id="api_qr_code"></div>

--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -2091,7 +2091,7 @@ Rating: {rating}/10   --> Rating: /10
                     or manually enter the connection info and device token into the app settings. This window will automatically close once device registration is successful.
                 </p>
                 <p class="help-block">
-                    Note: The Tautulli Remote relay (and OneSignal.com, for app versions before the relay) must not be blocked (e.g. in Pi-hole) for device registration.
+                    Note: relay.tautulliremote.com must not be blocked (e.g. in Pi-hole) for device registration.
                 </p>
                 <label>QR Code</label>
                 <div id="api_qr_code"></div>

--- a/data/interfaces/default/settings.html
+++ b/data/interfaces/default/settings.html
@@ -2091,7 +2091,7 @@ Rating: {rating}/10   --> Rating: /10
                     or manually enter the connection info and device token into the app settings. This window will automatically close once device registration is successful.
                 </p>
                 <p class="help-block">
-                    Note: OneSignal.com must not be blocked (e.g. in Pi-hole) for device registration.
+                    Note: The Tautulli push relay (and OneSignal.com, for app versions before the relay) must not be blocked (e.g. in Pi-hole) for device registration.
                 </p>
                 <label>QR Code</label>
                 <div id="api_qr_code"></div>

--- a/plexpy/__init__.py
+++ b/plexpy/__init__.py
@@ -260,9 +260,6 @@ def initialize(config_file):
         notifiers.blacklist_logger()
         mobile_app.blacklist_logger()
 
-        # Repair any device left unvalidated by an earlier outage
-        mobile_app.revalidate_devices()
-
         # Check if Tautulli has a uuid
         if CONFIG.PMS_UUID == '' or not CONFIG.PMS_UUID:
             logger.debug("Generating UUID...")
@@ -546,6 +543,9 @@ def start():
         # Start background notification thread
         notification_handler.start_threads(num_threads=CONFIG.NOTIFICATION_THREADS)
         notifiers.check_browser_enabled()
+
+        # Repair any device left unvalidated by an earlier outage
+        mobile_app.revalidate_devices()
 
         # Schedule newsletters
         newsletter_handler.NEWSLETTER_SCHED.start()

--- a/plexpy/__init__.py
+++ b/plexpy/__init__.py
@@ -260,6 +260,9 @@ def initialize(config_file):
         notifiers.blacklist_logger()
         mobile_app.blacklist_logger()
 
+        # Repair any device left unvalidated by an earlier outage
+        mobile_app.revalidate_onesignal_ids()
+
         # Check if Tautulli has a uuid
         if CONFIG.PMS_UUID == '' or not CONFIG.PMS_UUID:
             logger.debug("Generating UUID...")
@@ -2880,11 +2883,6 @@ def dbcheck():
 
 def upgrade():
     logger.info("Checking if the configurastion upgrades are required...")
-
-    if CONFIG.UPGRADE_FLAG == 0:
-        mobile_app.revalidate_onesignal_ids()
-        CONFIG.UPGRADE_FLAG = 1
-        CONFIG.write()
 
     logger.info("Configuration upgrade complete.")
 

--- a/plexpy/__init__.py
+++ b/plexpy/__init__.py
@@ -261,7 +261,7 @@ def initialize(config_file):
         mobile_app.blacklist_logger()
 
         # Repair any device left unvalidated by an earlier outage
-        mobile_app.revalidate_onesignal_ids()
+        mobile_app.revalidate_devices()
 
         # Check if Tautulli has a uuid
         if CONFIG.PMS_UUID == '' or not CONFIG.PMS_UUID:

--- a/plexpy/__init__.py
+++ b/plexpy/__init__.py
@@ -811,7 +811,7 @@ def dbcheck():
         "CREATE TABLE IF NOT EXISTS mobile_devices (id INTEGER PRIMARY KEY AUTOINCREMENT, "
         "device_id TEXT NOT NULL UNIQUE, device_token TEXT, device_name TEXT, "
         "platform TEXT, version TEXT, friendly_name TEXT, "
-        "onesignal_id TEXT, last_seen INTEGER, official INTEGER DEFAULT 0)"
+        "onesignal_id TEXT, push_token TEXT, last_seen INTEGER, official INTEGER DEFAULT 0)"
     )
 
     # tvmaze_lookup table :: This table keeps record of the TVmaze lookups
@@ -2398,6 +2398,15 @@ def dbcheck():
                 "SELECT device_id FROM mobile_devices WHERE official > 0").fetchall():
             c_db.execute("UPDATE mobile_devices SET platform = ? WHERE device_id = ?",
                          ["android", device_id])
+
+    # Upgrade mobile_devices table from earlier versions
+    try:
+        c_db.execute("SELECT push_token FROM mobile_devices")
+    except sqlite3.OperationalError:
+        logger.debug("Altering database. Updating database table mobile_devices.")
+        c_db.execute(
+            "ALTER TABLE mobile_devices ADD COLUMN push_token TEXT"
+        )
 
     # Upgrade notifiers table from earlier versions
     try:

--- a/plexpy/api2.py
+++ b/plexpy/api2.py
@@ -375,7 +375,7 @@ class API2(object):
         return data
 
     def register_device(self, device_id='', device_name='', platform=None, version=None,
-                        friendly_name='', onesignal_id=None, min_version='', **kwargs):
+                        friendly_name='', onesignal_id=None, push_token=None, min_version='', **kwargs):
         """ Registers the Tautulli Remote App.
 
             ```
@@ -388,6 +388,7 @@ class API2(object):
                 version (str):            The version of the app
                 friendly_name (str):      A friendly name to identify the mobile device
                 onesignal_id (str):       The OneSignal id for the mobile device
+                push_token (str):         The push notification token for the mobile device
                 min_version (str):        The minimum Tautulli version supported by the mobile device, e.g. v2.5.6
 
             Returns:
@@ -433,7 +434,9 @@ class API2(object):
             return
 
         ## TODO: Temporary for backwards compatibility, assume device_id is onesignal_id
-        if device_id and onesignal_id is None:
+        # App versions that register a push token always send onesignal_id explicitly,
+        # so this only applies to older apps that predate both.
+        if device_id and onesignal_id is None and push_token is None:
             onesignal_id = device_id
 
         result = mobile_app.add_mobile_device(device_id=device_id,
@@ -442,7 +445,8 @@ class API2(object):
                                               platform=platform,
                                               version=version,
                                               friendly_name=friendly_name,
-                                              onesignal_id=onesignal_id)
+                                              onesignal_id=onesignal_id,
+                                              push_token=push_token)
 
         if result:
             self._api_msg = 'Device registration successful.'
@@ -707,6 +711,8 @@ General optional parameters:
                 logger._BLACKLIST_WORDS.add(kwargs['device_id'])
             if kwargs.get('onesignal_id'):
                 logger._BLACKLIST_WORDS.add(kwargs['onesignal_id'])
+            if kwargs.get('push_token'):
+                logger._BLACKLIST_WORDS.add(kwargs['push_token'])
 
         result = None
         logger.api_debug('Tautulli APIv2 :: API called with kwargs: %s' % kwargs)

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -182,6 +182,7 @@ _CONFIG_DEFINITIONS = {
     'REFRESH_LIBRARIES_ON_STARTUP': (int, 'Monitoring', 1),
     'REFRESH_USERS_INTERVAL': (int, 'Monitoring', 12),
     'REFRESH_USERS_ON_STARTUP': (int, 'Monitoring', 1),
+    'REMOTE_APP_PUSH_URL': (str, 'Advanced', 'https://relay.tautulliremote.com'),
     'SESSION_DB_WRITE_ATTEMPTS': (int, 'Advanced', 5),
     'SHOW_ADVANCED_SETTINGS': (int, 'General', 0),
     'SYNCHRONOUS_MODE': (str, 'Advanced', 'NORMAL'),

--- a/plexpy/config.py
+++ b/plexpy/config.py
@@ -192,7 +192,6 @@ _CONFIG_DEFINITIONS = {
     'TV_WATCHED_PERCENT': (int, 'Monitoring', 85),
     'UPDATE_DB_INTERVAL': (int, 'General', 24),
     'UPDATE_SHOW_CHANGELOG': (int, 'General', 1),
-    'UPGRADE_FLAG': (int, 'Advanced', 0),
     'VERBOSE_LOGS': (int, 'Advanced', 1),
     'VERIFY_SSL_CERT': (bool_int, 'Advanced', 1),
     'WATCHED_MARKER': (int, 'Monitoring', 3),

--- a/plexpy/mobile_app.py
+++ b/plexpy/mobile_app.py
@@ -224,7 +224,11 @@ def set_official(device_id, onesignal_id, push_token=None):
                            + where,
                            args=[official, platform, device_id])
     except Exception as e:
-        logger.warn("Tautulli MobileApp :: Failed to set official flag for device: %s." % e)
+        # No device identifier here: this runs for both transports, and a
+        # OneSignal device has nothing loggable to name it by. Its device id and
+        # OneSignal id are both blacklisted, which is why the OneSignal
+        # validation lines carry no identifier either.
+        logger.warn("Tautulli MobileApp :: Failed to set official flag: %s." % e)
         return
 
 
@@ -246,7 +250,8 @@ def set_official_from_delivery(device, official):
         db.action("UPDATE mobile_devices SET official = ? WHERE device_id = ?",
                   args=[official, device['device_id']])
     except Exception as e:
-        logger.warn("Tautulli MobileApp :: Failed to set official flag for device: %s." % e)
+        logger.warn("Tautulli MobileApp :: Failed to set official flag for device %s: %s."
+                    % (relay_device_id(device['push_token']), e))
 
 
 def set_last_seen(device_token=None):

--- a/plexpy/mobile_app.py
+++ b/plexpy/mobile_app.py
@@ -272,8 +272,9 @@ def validate_push_token(push_token):
 
     logger.info("Tautulli MobileApp :: Validating push token for device %s", device_id)
     try:
+        # A 307 or 308 would re-post the push token to wherever Location points.
         r = requests.post('%s/v1/validate' % plexpy.CONFIG.REMOTE_APP_PUSH_URL.rstrip('/'),
-                          headers=headers, json=payload, timeout=10)
+                          headers=headers, json=payload, timeout=10, allow_redirects=False)
         status_code = r.status_code
         logger.info("Tautulli MobileApp :: Push token validation for device %s returned status code %s",
                     device_id, status_code)

--- a/plexpy/mobile_app.py
+++ b/plexpy/mobile_app.py
@@ -15,6 +15,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with Tautulli.  If not, see <http://www.gnu.org/licenses/>.
 
+import hashlib
 import requests
 import threading
 import time
@@ -35,6 +36,19 @@ _PUSH_DISABLED = 'push-disabled'
 _REVALIDATE_INTERVAL = 2
 
 TEMP_DEVICE_TOKENS = {}
+
+
+def relay_device_id(push_token):
+    """Return the identifier the push relay knows a device by.
+
+    The push token is a credential and is blacklisted from the logs, so it
+    cannot be used to say which device a log line is about. The relay derives
+    this same digest, and Tautulli Remote shows it on its data dump page, so
+    one string ties a user's report, this log and the relay's records together.
+    """
+    if not push_token or push_token == _PUSH_DISABLED:
+        return 'none'
+    return hashlib.sha256(push_token.encode()).hexdigest()[:16]
 
 
 def set_temp_device_token(token=None, remove=False, add=False, success=False):
@@ -137,6 +151,11 @@ def get_mobile_device_config(mobile_device_id=None):
 
     if result['push_token'] == _PUSH_DISABLED:
         result['push_token'] = ''
+
+    # Shown in place of the token itself, which is a credential the admin has no
+    # use for. This is the value the relay records and the app displays, so it is
+    # the one worth quoting in a bug report.
+    result['relay_device_id'] = relay_device_id(result['push_token']) if result['push_token'] else ''
 
     return result
 
@@ -270,12 +289,15 @@ def validate_push_token(push_token):
     headers = {'Content-Type': 'application/json'}
     payload = {'token': push_token}
 
-    logger.info("Tautulli MobileApp :: Validating push token")
+    device_id = relay_device_id(push_token)
+
+    logger.info("Tautulli MobileApp :: Validating push token for device %s", device_id)
     try:
         r = requests.post('%s/v1/validate' % plexpy.CONFIG.REMOTE_APP_PUSH_URL.rstrip('/'),
                           headers=headers, json=payload, timeout=10)
         status_code = r.status_code
-        logger.info("Tautulli MobileApp :: Push token validation returned status code %s", status_code)
+        logger.info("Tautulli MobileApp :: Push token validation for device %s returned status code %s",
+                    device_id, status_code)
         if status_code == 200:
             return 1
         elif status_code == 410:
@@ -284,7 +306,7 @@ def validate_push_token(push_token):
         # the token itself, so do not mark the device as invalid.
         return -1
     except Exception as e:
-        logger.warn("Tautulli MobileApp :: Failed to validate push token: %s." % e)
+        logger.warn("Tautulli MobileApp :: Failed to validate push token for device %s: %s." % (device_id, e))
         return -1
 
 

--- a/plexpy/mobile_app.py
+++ b/plexpy/mobile_app.py
@@ -270,7 +270,7 @@ def validate_push_token(push_token):
     logger.info("Tautulli MobileApp :: Validating push token for device %s", device_id)
     try:
         # A 307 or 308 would re-post the push token to wherever Location points.
-        r = requests.post('%s/v1/validate' % plexpy.CONFIG.REMOTE_APP_PUSH_URL.rstrip('/'),
+        r = requests.post(f"{plexpy.CONFIG.REMOTE_APP_PUSH_URL.rstrip('/')}/v1/validate",
                           json=payload, timeout=10,
                           allow_redirects=False)
         status_code = r.status_code

--- a/plexpy/mobile_app.py
+++ b/plexpy/mobile_app.py
@@ -260,9 +260,7 @@ def validate_onesignal_id(onesignal_id):
 
 
 def validate_push_token(push_token):
-    if push_token is None:
-        return 0
-    elif push_token == _PUSH_DISABLED:
+    if push_token == _PUSH_DISABLED:
         return 2
 
     headers = {'Content-Type': 'application/json'}
@@ -298,7 +296,7 @@ def validates_remotely(device):
     return bool(device['onesignal_id']) and device['onesignal_id'] != _ONESIGNAL_DISABLED
 
 
-def revalidate_onesignal_ids():
+def revalidate_devices():
     # Runs on every startup; threaded so a blocked host cannot hold up boot.
     threading.Thread(target=_revalidate_devices).start()
 

--- a/plexpy/mobile_app.py
+++ b/plexpy/mobile_app.py
@@ -196,8 +196,6 @@ def set_official(device_id, onesignal_id, push_token=None):
     else:
         official = validate_onesignal_id(onesignal_id=onesignal_id)
 
-    platform = 'android' if official > 0 else None
-
     # An indeterminate result says nothing about the token, so don't let it
     # clear a device that has already validated.
     where = "WHERE device_id = ?"
@@ -206,9 +204,9 @@ def set_official(device_id, onesignal_id, push_token=None):
 
     try:
         result = db.action("UPDATE mobile_devices "
-                           "SET official = ?, platform = coalesce(platform, ?) "
+                           "SET official = ? "
                            "%s" % where,
-                           args=[official, platform, device_id])
+                           args=[official, device_id])
     except Exception as e:
         logger.warn("Tautulli MobileApp :: Failed to set official flag: %s." % e)
         return

--- a/plexpy/mobile_app.py
+++ b/plexpy/mobile_app.py
@@ -263,7 +263,6 @@ def validate_push_token(push_token):
     if push_token == _PUSH_DISABLED:
         return 2
 
-    headers = {'Content-Type': 'application/json'}
     payload = {'token': push_token}
 
     device_id = relay_device_id(push_token)
@@ -273,7 +272,7 @@ def validate_push_token(push_token):
         # A 307 or 308 would re-post the push token to wherever Location points. The relay
         # is verified regardless of VERIFY_SSL_CERT.
         r = requests.post('%s/v1/validate' % plexpy.CONFIG.REMOTE_APP_PUSH_URL.rstrip('/'),
-                          headers=headers, json=payload, timeout=10,
+                          json=payload, timeout=10,
                           allow_redirects=False, verify=True)
         status_code = r.status_code
         logger.info("Tautulli MobileApp :: Push token validation for device %s returned status code %s",

--- a/plexpy/mobile_app.py
+++ b/plexpy/mobile_app.py
@@ -296,14 +296,14 @@ def validates_remotely(device):
 
 
 def revalidate_onesignal_ids():
-    # One network round trip per device, called from the startup path.
+    # Runs on every startup; threaded so a blocked host cannot hold up boot.
     threading.Thread(target=_revalidate_devices).start()
 
 
 def _revalidate_devices():
-    # Only repair unknown or failed state; re-checking healthy devices risks
-    # tripping the relay's per-IP limit on /v1/validate.
-    devices = [d for d in get_mobile_devices() if d['official'] != 1]
+    # Re-validating a healthy device risks the relay's per-IP limit on
+    # /v1/validate, and a device that opted out has no registration to check.
+    devices = [d for d in get_mobile_devices() if d['official'] != 1 and validates_remotely(d)]
 
     if not devices:
         return
@@ -312,8 +312,7 @@ def _revalidate_devices():
 
     for device in devices:
         set_official(device['device_id'], device['onesignal_id'], device['push_token'])
-        if validates_remotely(device):
-            time.sleep(_REVALIDATE_INTERVAL)
+        time.sleep(_REVALIDATE_INTERVAL)
 
 
 def blacklist_logger():

--- a/plexpy/mobile_app.py
+++ b/plexpy/mobile_app.py
@@ -17,7 +17,9 @@
 
 import requests
 import threading
+import time
 
+import plexpy
 from plexpy import database
 from plexpy import helpers
 from plexpy import logger
@@ -25,6 +27,12 @@ from plexpy import logger
 
 _ONESIGNAL_APP_ID = '3b4b666a-d557-4b92-acdf-e2c8c4b95357'
 _ONESIGNAL_DISABLED = 'onesignal-disabled'
+_PUSH_DISABLED = 'push-disabled'
+
+# Seconds to wait between validations when revalidating the whole device list.
+# The push relay rate limits /v1/validate per client IP, so a server with a long
+# list has to pace itself or the tail of the sweep is refused.
+_REVALIDATE_INTERVAL = 2
 
 TEMP_DEVICE_TOKENS = {}
 
@@ -81,7 +89,8 @@ def get_mobile_device_by_token(device_token=None):
 
 
 def add_mobile_device(device_id=None, device_name=None, device_token=None,
-                      platform=None, version=None, friendly_name=None, onesignal_id=None):
+                      platform=None, version=None, friendly_name=None, onesignal_id=None,
+                      push_token=None):
     db = database.MonitorDatabase()
 
     keys = {'device_id': device_id}
@@ -89,7 +98,8 @@ def add_mobile_device(device_id=None, device_name=None, device_token=None,
               'device_token': device_token,
               'platform': platform,
               'version': version,
-              'onesignal_id': onesignal_id}
+              'onesignal_id': onesignal_id,
+              'push_token': push_token}
 
     if friendly_name:
         values['friendly_name'] = friendly_name
@@ -107,7 +117,7 @@ def add_mobile_device(device_id=None, device_name=None, device_token=None,
         logger.info("Tautulli MobileApp :: Re-registered mobile device '%s' in the database." % device_name)
 
     set_last_seen(device_token=device_token)
-    threading.Thread(target=set_official, args=[device_id, onesignal_id]).start()
+    threading.Thread(target=set_official, args=[device_id, onesignal_id, push_token]).start()
     return True
 
 
@@ -124,6 +134,9 @@ def get_mobile_device_config(mobile_device_id=None):
 
     if result['onesignal_id'] == _ONESIGNAL_DISABLED:
         result['onesignal_id'] = ''
+
+    if result['push_token'] == _PUSH_DISABLED:
+        result['push_token'] = ''
 
     return result
 
@@ -164,19 +177,57 @@ def delete_mobile_device(mobile_device_id=None, device_id=None):
         return False
 
 
-def set_official(device_id, onesignal_id):
+def set_official(device_id, onesignal_id, push_token=None):
     db = database.MonitorDatabase()
-    official = validate_onesignal_id(onesignal_id=onesignal_id)
+
+    # Devices registered by app versions that use the push relay send a push
+    # token; older versions only send a OneSignal ID. Validate whichever the
+    # device actually registered with.
+    if push_token:
+        official = validate_push_token(push_token=push_token)
+    else:
+        official = validate_onesignal_id(onesignal_id=onesignal_id)
+
     platform = 'android' if official > 0 else None
+
+    # An indeterminate result (rate limited, relay or FCM outage, network error)
+    # says nothing about the token itself, so it must not clear a device that has
+    # already validated: that would drop the device out of the notifier device
+    # list until the user re-registered it from the app by hand. Devices with no
+    # successful validation to lose still record the failure.
+    where = "WHERE device_id = ?"
+    if official == -1:
+        where += " AND coalesce(official, 0) != 1"
 
     try:
         result = db.action("UPDATE mobile_devices "
                            "SET official = ?, platform = coalesce(platform, ?) "
-                           "WHERE device_id = ?",
+                           + where,
                            args=[official, platform, device_id])
     except Exception as e:
         logger.warn("Tautulli MobileApp :: Failed to set official flag for device: %s." % e)
         return
+
+
+def set_official_from_delivery(device, official):
+    """Re-derive the official flag from the outcome of a real notification.
+
+    The relay accepting a notification (200) proves FCM holds the token, which is
+    exactly what /v1/validate checks, and a 410 proves it never will again. Using
+    the delivery itself as the signal costs no extra request and lets a device
+    left in a failed state — a validation that was rate limited or interrupted —
+    recover without the user having to re-register it.
+    """
+    if device['official'] == official:
+        return
+
+    db = database.MonitorDatabase()
+
+    try:
+        db.action("UPDATE mobile_devices SET official = ? WHERE device_id = ?",
+                  args=[official, device['device_id']])
+    except Exception as e:
+        logger.warn("Tautulli MobileApp :: Failed to set official flag for device: %s." % e)
 
 
 def set_last_seen(device_token=None):
@@ -210,9 +261,68 @@ def validate_onesignal_id(onesignal_id):
         return -1
 
 
+def validate_push_token(push_token):
+    if push_token is None:
+        return 0
+    elif push_token == _PUSH_DISABLED:
+        return 2
+
+    headers = {'Content-Type': 'application/json'}
+    payload = {'token': push_token}
+
+    logger.info("Tautulli MobileApp :: Validating push token")
+    try:
+        r = requests.post('%s/v1/validate' % plexpy.CONFIG.REMOTE_APP_PUSH_URL.rstrip('/'),
+                          headers=headers, json=payload, timeout=10)
+        status_code = r.status_code
+        logger.info("Tautulli MobileApp :: Push token validation returned status code %s", status_code)
+        if status_code == 200:
+            return 1
+        elif status_code == 410:
+            return 0
+        # Anything else (rate limited, relay or FCM outage) says nothing about
+        # the token itself, so do not mark the device as invalid.
+        return -1
+    except Exception as e:
+        logger.warn("Tautulli MobileApp :: Failed to validate push token: %s." % e)
+        return -1
+
+
+def validates_remotely(device):
+    """Whether validating this device costs a request to the relay or OneSignal.
+
+    A device registered with a disabled sentinel, or with neither ID, is resolved
+    locally and so does not need to be paced.
+    """
+    if device['push_token']:
+        return device['push_token'] != _PUSH_DISABLED
+    return bool(device['onesignal_id']) and device['onesignal_id'] != _ONESIGNAL_DISABLED
+
+
 def revalidate_onesignal_ids():
-    for device in get_mobile_devices():
-        set_official(device['device_id'], device['onesignal_id'])
+    # One network round trip per device, called from the startup path.
+    threading.Thread(target=_revalidate_devices).start()
+
+
+def _revalidate_devices():
+    """Re-check every device whose registration has not validated successfully.
+
+    Devices already marked official are skipped: the sweep exists to repair
+    unknown or failed state, and rechecking a healthy device list would only risk
+    tripping the relay's per-IP limit on /v1/validate and clearing the very flag
+    it is meant to confirm.
+    """
+    devices = [d for d in get_mobile_devices() if d['official'] != 1]
+
+    if not devices:
+        return
+
+    logger.info("Tautulli MobileApp :: Validating %s mobile device registration(s).", len(devices))
+
+    for device in devices:
+        set_official(device['device_id'], device['onesignal_id'], device['push_token'])
+        if validates_remotely(device):
+            time.sleep(_REVALIDATE_INTERVAL)
 
 
 def blacklist_logger():

--- a/plexpy/mobile_app.py
+++ b/plexpy/mobile_app.py
@@ -269,11 +269,10 @@ def validate_push_token(push_token):
 
     logger.info("Tautulli MobileApp :: Validating push token for device %s", device_id)
     try:
-        # A 307 or 308 would re-post the push token to wherever Location points. The relay
-        # is verified regardless of VERIFY_SSL_CERT.
+        # A 307 or 308 would re-post the push token to wherever Location points.
         r = requests.post('%s/v1/validate' % plexpy.CONFIG.REMOTE_APP_PUSH_URL.rstrip('/'),
                           json=payload, timeout=10,
-                          allow_redirects=False, verify=True)
+                          allow_redirects=False)
         status_code = r.status_code
         logger.info("Tautulli MobileApp :: Push token validation for device %s returned status code %s",
                     device_id, status_code)

--- a/plexpy/mobile_app.py
+++ b/plexpy/mobile_app.py
@@ -30,21 +30,15 @@ _ONESIGNAL_APP_ID = '3b4b666a-d557-4b92-acdf-e2c8c4b95357'
 _ONESIGNAL_DISABLED = 'onesignal-disabled'
 _PUSH_DISABLED = 'push-disabled'
 
-# Seconds to wait between validations when revalidating the whole device list.
-# The push relay rate limits /v1/validate per client IP, so a server with a long
-# list has to pace itself or the tail of the sweep is refused.
-_REVALIDATE_INTERVAL = 2
+_REVALIDATE_INTERVAL = 2  # seconds; the relay rate limits /v1/validate per client IP
 
 TEMP_DEVICE_TOKENS = {}
 
 
 def relay_device_id(push_token):
-    """Return the identifier the push relay knows a device by.
-
-    The push token is a credential and is blacklisted from the logs, so it
-    cannot be used to say which device a log line is about. The relay derives
-    this same digest, and Tautulli Remote shows it on its data dump page, so
-    one string ties a user's report, this log and the relay's records together.
+    """
+    Return the identifier the relay records and Tautulli Remote shows on its
+    data dump page. The push token itself is blacklisted from the logs.
     """
     if not push_token or push_token == _PUSH_DISABLED:
         return 'none'
@@ -152,9 +146,6 @@ def get_mobile_device_config(mobile_device_id=None):
     if result['push_token'] == _PUSH_DISABLED:
         result['push_token'] = ''
 
-    # Shown in place of the token itself, which is a credential the admin has no
-    # use for. This is the value the relay records and the app displays, so it is
-    # the one worth quoting in a bug report.
     result['relay_device_id'] = relay_device_id(result['push_token']) if result['push_token'] else ''
 
     return result
@@ -199,9 +190,7 @@ def delete_mobile_device(mobile_device_id=None, device_id=None):
 def set_official(device_id, onesignal_id, push_token=None):
     db = database.MonitorDatabase()
 
-    # Devices registered by app versions that use the push relay send a push
-    # token; older versions only send a OneSignal ID. Validate whichever the
-    # device actually registered with.
+    # Newer app versions register a push token; older ones only send a OneSignal ID.
     if push_token:
         official = validate_push_token(push_token=push_token)
     else:
@@ -209,11 +198,8 @@ def set_official(device_id, onesignal_id, push_token=None):
 
     platform = 'android' if official > 0 else None
 
-    # An indeterminate result (rate limited, relay or FCM outage, network error)
-    # says nothing about the token itself, so it must not clear a device that has
-    # already validated: that would drop the device out of the notifier device
-    # list until the user re-registered it from the app by hand. Devices with no
-    # successful validation to lose still record the failure.
+    # An indeterminate result says nothing about the token, so don't let it
+    # clear a device that has already validated.
     where = "WHERE device_id = ?"
     if official == -1:
         where += " AND coalesce(official, 0) != 1"
@@ -221,26 +207,14 @@ def set_official(device_id, onesignal_id, push_token=None):
     try:
         result = db.action("UPDATE mobile_devices "
                            "SET official = ?, platform = coalesce(platform, ?) "
-                           + where,
+                           "%s" % where,
                            args=[official, platform, device_id])
     except Exception as e:
-        # No device identifier here: this runs for both transports, and a
-        # OneSignal device has nothing loggable to name it by. Its device id and
-        # OneSignal id are both blacklisted, which is why the OneSignal
-        # validation lines carry no identifier either.
         logger.warn("Tautulli MobileApp :: Failed to set official flag: %s." % e)
         return
 
 
 def set_official_from_delivery(device, official):
-    """Re-derive the official flag from the outcome of a real notification.
-
-    The relay accepting a notification (200) proves FCM holds the token, which is
-    exactly what /v1/validate checks, and a 410 proves it never will again. Using
-    the delivery itself as the signal costs no extra request and lets a device
-    left in a failed state — a validation that was rate limited or interrupted —
-    recover without the user having to re-register it.
-    """
     if device['official'] == official:
         return
 
@@ -316,11 +290,6 @@ def validate_push_token(push_token):
 
 
 def validates_remotely(device):
-    """Whether validating this device costs a request to the relay or OneSignal.
-
-    A device registered with a disabled sentinel, or with neither ID, is resolved
-    locally and so does not need to be paced.
-    """
     if device['push_token']:
         return device['push_token'] != _PUSH_DISABLED
     return bool(device['onesignal_id']) and device['onesignal_id'] != _ONESIGNAL_DISABLED
@@ -332,13 +301,8 @@ def revalidate_onesignal_ids():
 
 
 def _revalidate_devices():
-    """Re-check every device whose registration has not validated successfully.
-
-    Devices already marked official are skipped: the sweep exists to repair
-    unknown or failed state, and rechecking a healthy device list would only risk
-    tripping the relay's per-IP limit on /v1/validate and clearing the very flag
-    it is meant to confirm.
-    """
+    # Only repair unknown or failed state; re-checking healthy devices risks
+    # tripping the relay's per-IP limit on /v1/validate.
     devices = [d for d in get_mobile_devices() if d['official'] != 1]
 
     if not devices:

--- a/plexpy/mobile_app.py
+++ b/plexpy/mobile_app.py
@@ -272,9 +272,11 @@ def validate_push_token(push_token):
 
     logger.info("Tautulli MobileApp :: Validating push token for device %s", device_id)
     try:
-        # A 307 or 308 would re-post the push token to wherever Location points.
+        # A 307 or 308 would re-post the push token to wherever Location points. The relay
+        # is verified regardless of VERIFY_SSL_CERT.
         r = requests.post('%s/v1/validate' % plexpy.CONFIG.REMOTE_APP_PUSH_URL.rstrip('/'),
-                          headers=headers, json=payload, timeout=10, allow_redirects=False)
+                          headers=headers, json=payload, timeout=10,
+                          allow_redirects=False, verify=True)
         status_code = r.status_code
         logger.info("Tautulli MobileApp :: Push token validation for device %s returned status code %s",
                     device_id, status_code)

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -4016,6 +4016,13 @@ class TAUTULLIREMOTEAPP(Notifier):
                        'notification_type': 0
                        }
 
+    @staticmethod
+    def _via_relay(device):
+        # Devices registered with a push token go through the relay; older ones through
+        # OneSignal. A device that opted out holds the sentinel rather than an empty token.
+        push_token = device['push_token']
+        return bool(push_token) and push_token != mobile_app._PUSH_DISABLED
+
     def _trim_to_relay_limit(self, plaintext_data):
         if _CRYPTOGRAPHY:
             # Everything but the ciphertext; a 16 byte nonce or salt is 24 base64 characters.
@@ -4166,9 +4173,7 @@ class TAUTULLIREMOTEAPP(Notifier):
                           'rating_key': pretty_metadata.parameters.get('rating_key', ''),
                           'poster_thumb': pretty_metadata.parameters.get('poster_thumb', '')}
 
-        # Devices registered with a push token go through the relay; older ones through OneSignal.
-        push_token = device['push_token']
-        via_relay = bool(push_token) and push_token != mobile_app._PUSH_DISABLED
+        via_relay = self._via_relay(device)
 
         if via_relay and not self._trim_to_relay_limit(plaintext_data):
             return False
@@ -4265,6 +4270,19 @@ class TAUTULLIREMOTEAPP(Notifier):
         config_option[-1]['description'] += ('<br><br>Notifications are delivered through the Tautulli Remote relay '
             'and Google Firebase Cloud Messaging. The relay stores no notification content and only forwards '
             'the notification to your device.')
+
+        # Resolved the way agent_notify resolves it, by device_id and without the
+        # official filter get_devices() applies, so the notice cannot go missing while
+        # this agent is still delivering through OneSignal.
+        selected = mobile_app.get_mobile_devices(device_id=self.config['device_id']) \
+            if self.config['device_id'] else []
+
+        if selected and not self._via_relay(selected[0]):
+            config_option[-1]['description'] += ('<br>This device was registered with an older app version and is '
+                'delivered through <a href="' + helpers.anon_url('https://onesignal.com') + '" target="_blank" '
+                'rel="noreferrer">OneSignal</a> instead. Some user data is collected and cannot be encrypted. '
+                'Please read the <a href="' + helpers.anon_url('https://onesignal.com/privacy_policy') + '" '
+                'target="_blank" rel="noreferrer">OneSignal Privacy Policy</a> for more details.')
 
         devices = self.get_devices()
 

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -4092,10 +4092,12 @@ class TAUTULLIREMOTEAPP(Notifier):
         device_id = mobile_app.relay_device_id(device['push_token'])
 
         logger.info("Tautulli Notifiers :: Sending {name} notification...".format(name=self.NAME))
-        # A 307 or 308 would re-post the push token to wherever Location points.
+        # A 307 or 308 would re-post the push token to wherever Location points. The relay
+        # is verified regardless of VERIFY_SSL_CERT, which is for the user's own server.
         response, err_msg, _ = request.request_response2(url, 'POST', auto_raise=False,
                                                         headers=headers, json=payload,
-                                                        timeout=self.TIMEOUT, allow_redirects=False)
+                                                        timeout=self.TIMEOUT,
+                                                        allow_redirects=False, verify=True)
 
         if response is None:
             logger.error("Tautulli Notifiers :: {name} notification to device {id} failed.".format(name=self.NAME, id=device_id))

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -4140,7 +4140,7 @@ class TAUTULLIREMOTEAPP(Notifier):
                                  reset=rate_limits.get('resetsAt', 'the next reset')))
             else:
                 logger.error("Tautulli Notifiers :: {name} notification to device {device} failed: notifications "
-                             "are being rate limited. Retry after {retry} seconds.".format(
+                             "are being rate limited, so this one was dropped. Retry-After: {retry}.".format(
                                  name=self.NAME, device=device_label,
                                  retry=response.headers.get('Retry-After', 'unknown')))
 
@@ -4154,7 +4154,6 @@ class TAUTULLIREMOTEAPP(Notifier):
                          "returned status code {status}.".format(
                              name=self.NAME, device=device_label, status=response.status_code))
 
-        logger.debug("Tautulli Notifiers :: Request response: {}".format(request.server_message(response, True)))
         return False
 
     def agent_notify(self, subject='', body='', action='', notification_id=None, **kwargs):

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -4236,7 +4236,7 @@ class TAUTULLIREMOTEAPP(Notifier):
                 'input_type': 'help'
             })
 
-        config_option[-1]['description'] += ('<br><br>Notifications are delivered through the Tautulli push relay '
+        config_option[-1]['description'] += ('<br><br>Notifications are delivered through the Tautulli Remote relay '
             'and Google Firebase Cloud Messaging. The relay stores no notification content and only forwards '
             'the encrypted notification to your device.')
 

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -62,6 +62,13 @@ from plexpy import users
 
 BROWSER_NOTIFIERS = {}
 
+# The push relay refuses a notification whose data object exceeds this, because
+# FCM caps the whole message at 4096 bytes.
+_RELAY_MAX_DATA_BYTES = 3800
+# Notifications are sent from a small shared worker pool, so a relay that accepts
+# the connection and never answers must not hold a worker open.
+_RELAY_TIMEOUT = 10
+
 AGENT_IDS = {'growl': 0,
              'prowl': 1,
              'xbmc': 2,
@@ -4037,6 +4044,14 @@ class TAUTULLIREMOTEAPP(Notifier):
                           'rating_key': pretty_metadata.parameters.get('rating_key', ''),
                           'poster_thumb': pretty_metadata.parameters.get('poster_thumb', '')}
 
+        # Devices registered by app versions that use the push relay carry a push
+        # token; older devices are still delivered to through OneSignal.
+        push_token = device['push_token']
+        via_relay = bool(push_token) and push_token != mobile_app._PUSH_DISABLED
+
+        if via_relay:
+            self._trim_to_relay_limit(plaintext_data)
+
         #logger.debug("Plaintext data: {}".format(plaintext_data))
 
         if _CRYPTOGRAPHY:
@@ -4060,42 +4075,140 @@ class TAUTULLIREMOTEAPP(Notifier):
             #logger.debug("Nonce (base64): {}".format(base64.b64encode(nonce)))
             #logger.debug("Salt (base64): {}".format(base64.b64encode(salt)))
 
-            payload = {'app_id': mobile_app._ONESIGNAL_APP_ID,
-                       'include_subscription_ids': [device['onesignal_id']],
-                       'contents': {'en': 'Tautulli Notification'},
-                       'data': {'encrypted': True,
-                                'version': 2,
-                                'cipher_text': helpers.base64str(encrypted_data),
-                                'nonce': helpers.base64str(nonce),
-                                'salt': helpers.base64str(salt),
-                                'server_id': plexpy.CONFIG.PMS_UUID}
-                       }
+            data = {'encrypted': True,
+                    'version': 2,
+                    'cipher_text': helpers.base64str(encrypted_data),
+                    'nonce': helpers.base64str(nonce),
+                    'salt': helpers.base64str(salt),
+                    'server_id': plexpy.CONFIG.PMS_UUID}
         else:
             logger.warn("Tautulli Notifiers :: Cryptography library is missing. "
                         "Tautulli Remote app notifications will be sent unencrypted. "
                         "Install the library to encrypt the notifications.")
 
-            payload = {'app_id': mobile_app._ONESIGNAL_APP_ID,
-                       'include_subscription_ids': [device['onesignal_id']],
-                       'contents': {'en': 'Tautulli Notification'},
-                       'data': {'encrypted': False,
-                                'plain_text': plaintext_data,
-                                'server_id': plexpy.CONFIG.PMS_UUID}
-                       }
+            data = {'encrypted': False,
+                    'plain_text': plaintext_data,
+                    'server_id': plexpy.CONFIG.PMS_UUID}
 
-        #logger.debug("OneSignal payload: {}".format(payload))
+        #logger.debug("Notification data: {}".format(data))
 
         headers = {'Content-Type': 'application/json'}
 
+        if via_relay:
+            return self._send_via_relay(device, data, headers)
+
+        payload = {'app_id': mobile_app._ONESIGNAL_APP_ID,
+                   'include_subscription_ids': [device['onesignal_id']],
+                   'contents': {'en': 'Tautulli Notification'},
+                   'data': data
+                   }
+
         return self.make_request('https://api.onesignal.com/notifications', headers=headers, json=payload)
+
+    def _trim_to_relay_limit(self, plaintext_data):
+        """Shorten the notification body to what the relay will accept.
+
+        FCM caps a message at 4096 bytes, so the relay refuses a data object over
+        _RELAY_MAX_DATA_BYTES, and encryption inflates the plaintext by a base64
+        third plus a 16 byte tag. A long notification is worth delivering
+        shortened; failing it outright would drop it with no way for the user to
+        tell that the length was the reason.
+        """
+        # Everything the data object carries besides the ciphertext itself: the
+        # keys, the base64 nonce and salt (16 bytes each), and the server id.
+        envelope = {'encrypted': True, 'version': 2, 'cipher_text': '',
+                    'nonce': 'x' * 24, 'salt': 'x' * 24,
+                    'server_id': plexpy.CONFIG.PMS_UUID}
+        # base64 emits 4 characters per 3 bytes, rounding up, so invert that
+        # rather than scaling by three quarters: the two are not the same, and
+        # the difference is enough to land just over the limit.
+        room = _RELAY_MAX_DATA_BYTES - len(json.dumps(envelope))
+        budget = (room // 4) * 3 - 16
+
+        def encoded_length():
+            return len(json.dumps(plaintext_data).encode('utf-8'))
+
+        if encoded_length() <= budget:
+            return
+
+        body = plaintext_data['body']
+        low, high = 0, len(body)
+
+        while low < high:
+            mid = (low + high + 1) // 2
+            plaintext_data['body'] = body[:mid] + '…'
+            if encoded_length() <= budget:
+                low = mid
+            else:
+                high = mid - 1
+
+        plaintext_data['body'] = body[:low] + '…'
+        logger.warn("Tautulli Notifiers :: %s notification body shortened from %s to %s characters "
+                    "to fit the notification size limit." % (self.NAME, len(body), low))
+
+    def _send_via_relay(self, device, data, headers):
+        payload = {'token': device['push_token'],
+                   'platform': device['platform'] or 'android',
+                   'data': data}
+
+        url = '%s/v1/notify' % plexpy.CONFIG.REMOTE_APP_PUSH_URL.rstrip('/')
+        # Newlines would let a device name forge additional log entries.
+        device_name = ' '.join((device['friendly_name'] or device['device_name'] or '').split())
+
+        logger.info("Tautulli Notifiers :: Sending {name} notification...".format(name=self.NAME))
+        # Without a timeout a stalled relay would hold one of the shared
+        # notification worker threads open indefinitely, and two of them would
+        # stop every notifier and newsletter Tautulli has.
+        response, err_msg, req_msg = request.request_response2(url, 'POST', auto_raise=False,
+                                                              headers=headers, json=payload,
+                                                              timeout=_RELAY_TIMEOUT)
+
+        if response is None:
+            logger.error("Tautulli Notifiers :: {name} notification failed.".format(name=self.NAME))
+            if err_msg:
+                logger.error("Tautulli Notifiers :: {}".format(err_msg))
+            return False
+
+        if response.status_code == 200:
+            logger.info("Tautulli Notifiers :: {name} notification sent.".format(name=self.NAME))
+            # Delivery proves the token is live, so a device whose validation was
+            # refused or interrupted heals itself here instead of needing to be
+            # registered again from the app.
+            mobile_app.set_official_from_delivery(device, 1)
+            return True
+
+        elif response.status_code == 410:
+            # The relay reports the device can never be delivered to again.
+            mobile_app.set_official_from_delivery(device, 0)
+            logger.error("Tautulli Notifiers :: {name} notification failed: the push token for device '{device}' "
+                         "is no longer valid. Open Tautulli Remote on the device to register it again."
+                         .format(name=self.NAME, device=device_name))
+
+        elif response.status_code == 429:
+            logger.error("Tautulli Notifiers :: {name} notification failed: the notification limit for device "
+                         "'{device}' has been reached. Retry after {retry} seconds."
+                         .format(name=self.NAME, device=device_name,
+                                 retry=response.headers.get('Retry-After', 'unknown')))
+
+        elif response.status_code == 413:
+            logger.error("Tautulli Notifiers :: {name} notification failed: the notification is too large to "
+                         "deliver. Shorten the notification text.".format(name=self.NAME))
+
+        else:
+            logger.error("Tautulli Notifiers :: {name} notification failed: the push relay returned status code "
+                         "{status}.".format(name=self.NAME, status=response.status_code))
+
+        logger.debug("Tautulli Notifiers :: Request response: {}".format(response.text))
+        return False
 
     def get_devices(self):
         db = database.MonitorDatabase()
 
         try:
             query = "SELECT * FROM mobile_devices WHERE official = 1 " \
-                    "AND onesignal_id IS NOT NULL AND onesignal_id != ''"
-            return db.select(query=query)
+                    "AND ((push_token IS NOT NULL AND push_token != '' AND push_token != ?) " \
+                    "OR (onesignal_id IS NOT NULL AND onesignal_id != ''))"
+            return db.select(query=query, args=[mobile_app._PUSH_DISABLED])
         except Exception as e:
             logger.warn("Tautulli Notifiers :: Unable to retrieve Tautulli Remote app devices list: %s." % e)
             return []
@@ -4123,22 +4236,19 @@ class TAUTULLIREMOTEAPP(Notifier):
                 'input_type': 'help'
             })
 
-        config_option[-1]['description'] += ('<br><br>Notifications are sent using '
-            '<a href="' + helpers.anon_url('https://onesignal.com') + '" target="_blank" rel="noreferrer">'
-            'OneSignal</a>. Some user data is collected and cannot be encrypted.<br>'
-            'Please read the <a href="' + helpers.anon_url(
-                'https://onesignal.com/privacy_policy') + '" target="_blank" rel="noreferrer">'
-            'OneSignal Privacy Policy</a> for more details.')
+        config_option[-1]['description'] += ('<br><br>Notifications are delivered through the Tautulli push relay '
+            'and Google Firebase Cloud Messaging. The relay stores no notification content and only forwards '
+            'the encrypted notification to your device.')
 
         devices = self.get_devices()
 
         if not devices:
             config_option.append({
                 'label': 'Device',
-                'description': 'No mobile devices registered with OneSignal. '
+                'description': 'No mobile devices registered for notifications. '
                                '<a data-tab-destination="remote_app" data-toggle="tab" data-dismiss="modal">'
                                'Get the Tautulli Remote App</a> and register a device.<br>'
-                               'Note: Only devices registered with a valid OneSignal ID will appear in the list.',
+                               'Note: Only devices registered for notifications will appear in the list.',
                 'input_type': 'help'
             })
         else:
@@ -4160,7 +4270,7 @@ class TAUTULLIREMOTEAPP(Notifier):
                 'description': 'Select your mobile device or '
                                '<a data-tab-destination="remote_app" data-toggle="tab" data-dismiss="modal">'
                                'register a new device</a> with Tautulli.<br>'
-                               'Note: Only devices registered with a valid OneSignal ID will appear in the list.',
+                               'Note: Only devices registered for notifications will appear in the list.',
                 'input_type': 'select',
                 'select_options': device_select,
                 'refresh': True

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -4159,9 +4159,9 @@ class TAUTULLIREMOTEAPP(Notifier):
         # Without a timeout a stalled relay would hold one of the shared
         # notification worker threads open indefinitely, and two of them would
         # stop every notifier and newsletter Tautulli has.
-        response, err_msg, req_msg = request.request_response2(url, 'POST', auto_raise=False,
-                                                              headers=headers, json=payload,
-                                                              timeout=_RELAY_TIMEOUT)
+        response, err_msg, _ = request.request_response2(url, 'POST', auto_raise=False,
+                                                        headers=headers, json=payload,
+                                                        timeout=_RELAY_TIMEOUT)
 
         if response is None:
             logger.error("Tautulli Notifiers :: {name} notification failed.".format(name=self.NAME))
@@ -4178,11 +4178,18 @@ class TAUTULLIREMOTEAPP(Notifier):
             return True
 
         elif response.status_code == 410:
-            # The relay reports the device can never be delivered to again.
+            # The relay reports the device can never be delivered to again. Clearing
+            # the official flag only removes it from the notifier config list, not
+            # from an agent already saved against it, so the sends keep coming. Say
+            # so at error level the first time and quietly thereafter, or a phone the
+            # user stopped using fills the log with one identical error per
+            # notification for as long as the agent stays configured.
+            was_official = device['official'] == 1
             mobile_app.set_official_from_delivery(device, 0)
-            logger.error("Tautulli Notifiers :: {name} notification failed: the push token for device '{device}' "
-                         "is no longer valid. Open Tautulli Remote on the device to register it again."
-                         .format(name=self.NAME, device=device_name))
+            log_dead_token = logger.error if was_official else logger.debug
+            log_dead_token("Tautulli Notifiers :: {name} notification failed: the push token for device '{device}' "
+                           "is no longer valid. Open Tautulli Remote on the device to register it again."
+                           .format(name=self.NAME, device=device_name))
 
         elif response.status_code == 429:
             logger.error("Tautulli Notifiers :: {name} notification failed: the notification limit for device "
@@ -4198,7 +4205,7 @@ class TAUTULLIREMOTEAPP(Notifier):
             logger.error("Tautulli Notifiers :: {name} notification failed: the push relay returned status code "
                          "{status}.".format(name=self.NAME, status=response.status_code))
 
-        logger.debug("Tautulli Notifiers :: Request response: {}".format(response.text))
+        logger.debug("Tautulli Notifiers :: Request response: {}".format(request.server_message(response, True)))
         return False
 
     def get_devices(self):

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -1,4 +1,4 @@
-﻿# -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 #  This file is part of Tautulli.
 #
@@ -61,13 +61,6 @@ from plexpy import users
 
 
 BROWSER_NOTIFIERS = {}
-
-# The push relay refuses a notification whose data object exceeds this, because
-# FCM caps the whole message at 4096 bytes.
-_RELAY_MAX_DATA_BYTES = 3800
-# Notifications are sent from a small shared worker pool, so a relay that accepts
-# the connection and never answers must not hold a worker open.
-_RELAY_TIMEOUT = 10
 
 AGENT_IDS = {'growl': 0,
              'prowl': 1,
@@ -4016,10 +4009,110 @@ class TAUTULLIREMOTEAPP(Notifier):
     Tautulli Remote app notifications
     """
     NAME = 'Tautulli Remote App'
+    MAX_DATA_BYTES = 3800  # the relay refuses a larger data object; FCM caps the message at 4096 bytes
+    TIMEOUT = 10  # notifications share a small worker pool, so a silent relay must not hold one open
     _DEFAULT_CONFIG = {'device_id': '',
                        'priority': 3,
                        'notification_type': 0
                        }
+
+    def _trim_to_relay_limit(self, plaintext_data):
+        # Everything but the ciphertext; a 16 byte nonce or salt is 24 base64 characters.
+        envelope = {'encrypted': True, 'version': 2, 'cipher_text': '',
+                    'nonce': 'x' * 24, 'salt': 'x' * 24,
+                    'server_id': plexpy.CONFIG.PMS_UUID}
+        # base64 emits 4 characters per 3 bytes rounding up, so invert that rather than scaling by three quarters.
+        room = self.MAX_DATA_BYTES - len(json.dumps(envelope))
+        budget = (room // 4) * 3 - 16
+
+        def encoded_length():
+            return len(json.dumps(plaintext_data).encode('utf-8'))
+
+        if encoded_length() <= budget:
+            return
+
+        body = plaintext_data['body']
+        low, high = 0, len(body)
+
+        while low < high:
+            mid = (low + high + 1) // 2
+            plaintext_data['body'] = body[:mid] + '...'
+            if encoded_length() <= budget:
+                low = mid
+            else:
+                high = mid - 1
+
+        plaintext_data['body'] = body[:low] + '...'
+        logger.warn("Tautulli Notifiers :: %s notification body shortened from %s to %s characters "
+                    "to fit the notification size limit." % (self.NAME, len(body), low))
+
+    def _send_via_relay(self, device, data, headers):
+        payload = {'token': device['push_token'],
+                   'platform': device['platform'] or 'android',
+                   'data': data}
+
+        url = '%s/v1/notify' % plexpy.CONFIG.REMOTE_APP_PUSH_URL.rstrip('/')
+        # Newlines would let a device name forge additional log entries.
+        device_name = ' '.join((device['friendly_name'] or device['device_name'] or '').split())
+        device_id = mobile_app.relay_device_id(device['push_token'])
+
+        logger.info("Tautulli Notifiers :: Sending {name} notification...".format(name=self.NAME))
+        response, err_msg, _ = request.request_response2(url, 'POST', auto_raise=False,
+                                                        headers=headers, json=payload,
+                                                        timeout=self.TIMEOUT)
+
+        if response is None:
+            logger.error("Tautulli Notifiers :: {name} notification to device {id} failed.".format(name=self.NAME, id=device_id))
+            if err_msg:
+                logger.error("Tautulli Notifiers :: {}".format(err_msg))
+            return False
+
+        if response.status_code == 200:
+            logger.info("Tautulli Notifiers :: {name} notification sent.".format(name=self.NAME))
+            # Delivery proves the token is live, so a device whose validation was
+            # refused or interrupted heals itself here.
+            mobile_app.set_official_from_delivery(device, 1)
+            return True
+
+        elif response.status_code == 410:
+            # Clearing the flag only drops the device from the notifier config list,
+            # not from an agent already saved against it, so report this once.
+            was_official = device['official'] == 1
+            mobile_app.set_official_from_delivery(device, 0)
+            log_dead_token = logger.error if was_official else logger.debug
+            log_dead_token("Tautulli Notifiers :: {name} notification failed: the push token for device '{device}' "
+                           "({id}) is no longer valid. Open Tautulli Remote on the device to register it "
+                           "again.".format(name=self.NAME, device=device_name, id=device_id))
+
+        elif response.status_code == 429:
+            # Only the daily fair use cap carries rate limit details, and unlike a
+            # burst refusal it will not clear until it resets.
+            try:
+                rate_limits = response.json().get('rateLimits') or {}
+            except ValueError:
+                rate_limits = {}
+
+            if rate_limits:
+                logger.error("Tautulli Notifiers :: {name} notification failed: the daily notification limit "
+                             "for device '{device}' ({id}) has been reached. Further notifications to this "
+                             "device will fail until the limit resets at {reset}.".format(name=self.NAME, device=device_name,
+                                                                                          id=device_id,
+                                                                                          reset=rate_limits.get('resetsAt', 'the next reset')))
+            else:
+                logger.error("Tautulli Notifiers :: {name} notification to device {id} failed: notifications "
+                             "are being rate limited. Retry after {retry} seconds.".format(name=self.NAME, id=device_id,
+                                                                                           retry=response.headers.get('Retry-After', 'unknown')))
+
+        elif response.status_code == 413:
+            logger.error("Tautulli Notifiers :: {name} notification to device {id} failed: the notification is "
+                         "too large to deliver. Shorten the notification text.".format(name=self.NAME, id=device_id))
+
+        else:
+            logger.error("Tautulli Notifiers :: {name} notification failed for device {id}: the push relay "
+                         "returned status code {status}.".format(name=self.NAME, id=device_id, status=response.status_code))
+
+        logger.debug("Tautulli Notifiers :: Request response: {}".format(request.server_message(response, True)))
+        return False
 
     def agent_notify(self, subject='', body='', action='', notification_id=None, **kwargs):
         # Check mobile device is still registered
@@ -4044,8 +4137,7 @@ class TAUTULLIREMOTEAPP(Notifier):
                           'rating_key': pretty_metadata.parameters.get('rating_key', ''),
                           'poster_thumb': pretty_metadata.parameters.get('poster_thumb', '')}
 
-        # Devices registered by app versions that use the push relay carry a push
-        # token; older devices are still delivered to through OneSignal.
+        # Devices registered with a push token go through the relay; older ones through OneSignal.
         push_token = device['push_token']
         via_relay = bool(push_token) and push_token != mobile_app._PUSH_DISABLED
 
@@ -4104,131 +4196,6 @@ class TAUTULLIREMOTEAPP(Notifier):
                    }
 
         return self.make_request('https://api.onesignal.com/notifications', headers=headers, json=payload)
-
-    def _trim_to_relay_limit(self, plaintext_data):
-        """Shorten the notification body to what the relay will accept.
-
-        FCM caps a message at 4096 bytes, so the relay refuses a data object over
-        _RELAY_MAX_DATA_BYTES, and encryption inflates the plaintext by a base64
-        third plus a 16 byte tag. A long notification is worth delivering
-        shortened; failing it outright would drop it with no way for the user to
-        tell that the length was the reason.
-        """
-        # Everything the data object carries besides the ciphertext itself: the
-        # keys, the base64 nonce and salt (16 bytes each), and the server id.
-        envelope = {'encrypted': True, 'version': 2, 'cipher_text': '',
-                    'nonce': 'x' * 24, 'salt': 'x' * 24,
-                    'server_id': plexpy.CONFIG.PMS_UUID}
-        # base64 emits 4 characters per 3 bytes, rounding up, so invert that
-        # rather than scaling by three quarters: the two are not the same, and
-        # the difference is enough to land just over the limit.
-        room = _RELAY_MAX_DATA_BYTES - len(json.dumps(envelope))
-        budget = (room // 4) * 3 - 16
-
-        def encoded_length():
-            return len(json.dumps(plaintext_data).encode('utf-8'))
-
-        if encoded_length() <= budget:
-            return
-
-        body = plaintext_data['body']
-        low, high = 0, len(body)
-
-        while low < high:
-            mid = (low + high + 1) // 2
-            plaintext_data['body'] = body[:mid] + '…'
-            if encoded_length() <= budget:
-                low = mid
-            else:
-                high = mid - 1
-
-        plaintext_data['body'] = body[:low] + '…'
-        logger.warn("Tautulli Notifiers :: %s notification body shortened from %s to %s characters "
-                    "to fit the notification size limit." % (self.NAME, len(body), low))
-
-    def _send_via_relay(self, device, data, headers):
-        payload = {'token': device['push_token'],
-                   'platform': device['platform'] or 'android',
-                   'data': data}
-
-        url = '%s/v1/notify' % plexpy.CONFIG.REMOTE_APP_PUSH_URL.rstrip('/')
-        # Newlines would let a device name forge additional log entries.
-        device_name = ' '.join((device['friendly_name'] or device['device_name'] or '').split())
-        # The name is what the user recognises; the relay id is what matches this
-        # log against the relay's own records and the app's data dump page.
-        device_id = mobile_app.relay_device_id(device['push_token'])
-
-        logger.info("Tautulli Notifiers :: Sending {name} notification...".format(name=self.NAME))
-        # Without a timeout a stalled relay would hold one of the shared
-        # notification worker threads open indefinitely, and two of them would
-        # stop every notifier and newsletter Tautulli has.
-        response, err_msg, _ = request.request_response2(url, 'POST', auto_raise=False,
-                                                        headers=headers, json=payload,
-                                                        timeout=_RELAY_TIMEOUT)
-
-        if response is None:
-            logger.error("Tautulli Notifiers :: {name} notification to device {id} failed."
-                         .format(name=self.NAME, id=device_id))
-            if err_msg:
-                logger.error("Tautulli Notifiers :: {}".format(err_msg))
-            return False
-
-        if response.status_code == 200:
-            logger.info("Tautulli Notifiers :: {name} notification sent.".format(name=self.NAME))
-            # Delivery proves the token is live, so a device whose validation was
-            # refused or interrupted heals itself here instead of needing to be
-            # registered again from the app.
-            mobile_app.set_official_from_delivery(device, 1)
-            return True
-
-        elif response.status_code == 410:
-            # The relay reports the device can never be delivered to again. Clearing
-            # the official flag only removes it from the notifier config list, not
-            # from an agent already saved against it, so the sends keep coming. Say
-            # so at error level the first time and quietly thereafter, or a phone the
-            # user stopped using fills the log with one identical error per
-            # notification for as long as the agent stays configured.
-            was_official = device['official'] == 1
-            mobile_app.set_official_from_delivery(device, 0)
-            log_dead_token = logger.error if was_official else logger.debug
-            log_dead_token("Tautulli Notifiers :: {name} notification failed: the push token for device '{device}' "
-                           "({id}) is no longer valid. Open Tautulli Remote on the device to register it again."
-                           .format(name=self.NAME, device=device_name, id=device_id))
-
-        elif response.status_code == 429:
-            # Two different refusals share this status. The daily fair use cap is
-            # the only one the relay attaches rate limit details to, and it is the
-            # one worth wording carefully: nothing this device sends will succeed
-            # until the cap resets, and Tautulli does not retry.
-            try:
-                rate_limits = response.json().get('rateLimits') or {}
-            except ValueError:
-                rate_limits = {}
-
-            if rate_limits:
-                logger.error("Tautulli Notifiers :: {name} notification failed: the daily notification limit "
-                             "for device '{device}' ({id}) has been reached. Further notifications to this "
-                             "device will fail until the limit resets at {reset}."
-                             .format(name=self.NAME, device=device_name, id=device_id,
-                                     reset=rate_limits.get('resetsAt', 'the next reset')))
-            else:
-                logger.error("Tautulli Notifiers :: {name} notification to device {id} failed: notifications "
-                             "are being rate limited. Retry after {retry} seconds."
-                             .format(name=self.NAME, id=device_id,
-                                     retry=response.headers.get('Retry-After', 'unknown')))
-
-        elif response.status_code == 413:
-            logger.error("Tautulli Notifiers :: {name} notification to device {id} failed: the notification is "
-                         "too large to deliver. Shorten the notification text."
-                         .format(name=self.NAME, id=device_id))
-
-        else:
-            logger.error("Tautulli Notifiers :: {name} notification failed for device {id}: the push relay "
-                         "returned status code {status}."
-                         .format(name=self.NAME, id=device_id, status=response.status_code))
-
-        logger.debug("Tautulli Notifiers :: Request response: {}".format(request.server_message(response, True)))
-        return False
 
     def get_devices(self):
         db = database.MonitorDatabase()

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -4017,34 +4017,62 @@ class TAUTULLIREMOTEAPP(Notifier):
                        }
 
     def _trim_to_relay_limit(self, plaintext_data):
-        # Everything but the ciphertext; a 16 byte nonce or salt is 24 base64 characters.
-        envelope = {'encrypted': True, 'version': 2, 'cipher_text': '',
-                    'nonce': 'x' * 24, 'salt': 'x' * 24,
-                    'server_id': plexpy.CONFIG.PMS_UUID}
-        # base64 emits 4 characters per 3 bytes rounding up, so invert that rather than scaling by three quarters.
-        room = self.MAX_DATA_BYTES - len(json.dumps(envelope))
-        budget = (room // 4) * 3 - 16
+        if _CRYPTOGRAPHY:
+            # Everything but the ciphertext; a 16 byte nonce or salt is 24 base64 characters.
+            envelope = {'encrypted': True, 'version': 2, 'cipher_text': '',
+                        'nonce': 'x' * 24, 'salt': 'x' * 24,
+                        'server_id': plexpy.CONFIG.PMS_UUID}
+            # base64 emits 4 characters per 3 bytes rounding up, so invert that rather than scaling by three quarters.
+            room = self.MAX_DATA_BYTES - len(json.dumps(envelope))
+            budget = (room // 4) * 3 - 16
+        else:
+            # Unencrypted, the plaintext is embedded as is and only pays for the keys around it.
+            envelope = {'encrypted': False, 'plain_text': '', 'server_id': plexpy.CONFIG.PMS_UUID}
+            budget = self.MAX_DATA_BYTES - len(json.dumps(envelope))
 
         def encoded_length():
             return len(json.dumps(plaintext_data).encode('utf-8'))
 
+        def trim(key):
+            text = plaintext_data[key]
+            low, high = 0, len(text)
+
+            while low < high:
+                mid = (low + high + 1) // 2
+                plaintext_data[key] = text[:mid] + '...'
+                if encoded_length() <= budget:
+                    low = mid
+                else:
+                    high = mid - 1
+
+            if low == len(text):
+                return None
+
+            plaintext_data[key] = text[:low] + '...'
+            return "%s shortened from %s to %s characters" % (key, len(text), low)
+
         if encoded_length() <= budget:
-            return
+            return True
 
-        body = plaintext_data['body']
-        low, high = 0, len(body)
-
-        while low < high:
-            mid = (low + high + 1) // 2
-            plaintext_data['body'] = body[:mid] + '...'
+        # The body goes first; the subject is the notification's headline, so it is
+        # only shortened when emptying the body was not enough.
+        trimmed = []
+        for key in ('body', 'subject'):
+            note = trim(key)
+            if note:
+                trimmed.append(note)
             if encoded_length() <= budget:
-                low = mid
-            else:
-                high = mid - 1
+                break
 
-        plaintext_data['body'] = body[:low] + '...'
-        logger.warn("Tautulli Notifiers :: %s notification body shortened from %s to %s characters "
-                    "to fit the notification size limit." % (self.NAME, len(body), low))
+        if encoded_length() > budget:
+            logger.error("Tautulli Notifiers :: %s notification is too large to send: %s bytes over the limit "
+                         "with no text left to remove. Shorten the notification text."
+                         % (self.NAME, encoded_length() - budget))
+            return False
+
+        logger.warn("Tautulli Notifiers :: %s notification %s to fit the notification size limit."
+                    % (self.NAME, ' and '.join(trimmed)))
+        return True
 
     def _send_via_relay(self, device, data, headers):
         payload = {'token': device['push_token'],
@@ -4141,8 +4169,8 @@ class TAUTULLIREMOTEAPP(Notifier):
         push_token = device['push_token']
         via_relay = bool(push_token) and push_token != mobile_app._PUSH_DISABLED
 
-        if via_relay:
-            self._trim_to_relay_limit(plaintext_data)
+        if via_relay and not self._trim_to_relay_limit(plaintext_data):
+            return False
 
         #logger.debug("Plaintext data: {}".format(plaintext_data))
 

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -4261,9 +4261,10 @@ class TAUTULLIREMOTEAPP(Notifier):
                 'input_type': 'help'
             })
 
+        # Appended to either block above, so it must hold with or without encryption.
         config_option[-1]['description'] += ('<br><br>Notifications are delivered through the Tautulli Remote relay '
             'and Google Firebase Cloud Messaging. The relay stores no notification content and only forwards '
-            'the encrypted notification to your device.')
+            'the notification to your device.')
 
         devices = self.get_devices()
 

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -4167,7 +4167,8 @@ class TAUTULLIREMOTEAPP(Notifier):
                                                         timeout=_RELAY_TIMEOUT)
 
         if response is None:
-            logger.error("Tautulli Notifiers :: {name} notification failed.".format(name=self.NAME))
+            logger.error("Tautulli Notifiers :: {name} notification to device {id} failed."
+                         .format(name=self.NAME, id=device_id))
             if err_msg:
                 logger.error("Tautulli Notifiers :: {}".format(err_msg))
             return False
@@ -4195,14 +4196,31 @@ class TAUTULLIREMOTEAPP(Notifier):
                            .format(name=self.NAME, device=device_name, id=device_id))
 
         elif response.status_code == 429:
-            logger.error("Tautulli Notifiers :: {name} notification failed: the notification limit for device "
-                         "'{device}' ({id}) has been reached. Retry after {retry} seconds."
-                         .format(name=self.NAME, device=device_name, id=device_id,
-                                 retry=response.headers.get('Retry-After', 'unknown')))
+            # Two different refusals share this status. The daily fair use cap is
+            # the only one the relay attaches rate limit details to, and it is the
+            # one worth wording carefully: nothing this device sends will succeed
+            # until the cap resets, and Tautulli does not retry.
+            try:
+                rate_limits = response.json().get('rateLimits') or {}
+            except ValueError:
+                rate_limits = {}
+
+            if rate_limits:
+                logger.error("Tautulli Notifiers :: {name} notification failed: the daily notification limit "
+                             "for device '{device}' ({id}) has been reached. Further notifications to this "
+                             "device will fail until the limit resets at {reset}."
+                             .format(name=self.NAME, device=device_name, id=device_id,
+                                     reset=rate_limits.get('resetsAt', 'the next reset')))
+            else:
+                logger.error("Tautulli Notifiers :: {name} notification to device {id} failed: notifications "
+                             "are being rate limited. Retry after {retry} seconds."
+                             .format(name=self.NAME, id=device_id,
+                                     retry=response.headers.get('Retry-After', 'unknown')))
 
         elif response.status_code == 413:
-            logger.error("Tautulli Notifiers :: {name} notification failed: the notification is too large to "
-                         "deliver. Shorten the notification text.".format(name=self.NAME))
+            logger.error("Tautulli Notifiers :: {name} notification to device {id} failed: the notification is "
+                         "too large to deliver. Shorten the notification text."
+                         .format(name=self.NAME, id=device_id))
 
         else:
             logger.error("Tautulli Notifiers :: {name} notification failed for device {id}: the push relay "

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -4082,16 +4082,24 @@ class TAUTULLIREMOTEAPP(Notifier):
         return True
 
     def _send_via_relay(self, device, data):
-        payload = {'token': device['push_token'],
-                   'platform': device['platform'] or 'android',
-                   'data': data}
-
         url = f"{plexpy.CONFIG.REMOTE_APP_PUSH_URL.rstrip('/')}/v1/notify"
         # Newlines would let a device name forge additional log entries.
         device_name = ' '.join((device['friendly_name'] or device['device_name'] or '').split())
         device_id = mobile_app.relay_device_id(device['push_token'])
         # The id alone is a token hash, so name the device wherever one is recorded.
         device_label = "'{}' ({})".format(device_name, device_id) if device_name else device_id
+
+        # The relay builds a different message per platform, and an iOS device sent
+        # as android gets one its notification extension never runs, so it is never
+        # decrypted and nothing is shown. Refusing says so; guessing does not.
+        if device['platform'] not in ('android', 'ios'):
+            logger.error("Tautulli Notifiers :: {name} notification to device {device} failed: unknown platform. "
+                         "Re-register the device in Tautulli Remote.".format(name=self.NAME, device=device_label))
+            return False
+
+        payload = {'token': device['push_token'],
+                   'platform': device['platform'],
+                   'data': data}
 
         logger.info("Tautulli Notifiers :: Sending {name} notification...".format(name=self.NAME))
         # A 307 or 308 would re-post the push token to wherever Location points. The relay

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -4090,6 +4090,8 @@ class TAUTULLIREMOTEAPP(Notifier):
         # Newlines would let a device name forge additional log entries.
         device_name = ' '.join((device['friendly_name'] or device['device_name'] or '').split())
         device_id = mobile_app.relay_device_id(device['push_token'])
+        # The id alone is a token hash, so name the device wherever one is recorded.
+        device_label = "'{}' ({})".format(device_name, device_id) if device_name else device_id
 
         logger.info("Tautulli Notifiers :: Sending {name} notification...".format(name=self.NAME))
         # A 307 or 308 would re-post the push token to wherever Location points. The relay
@@ -4099,7 +4101,8 @@ class TAUTULLIREMOTEAPP(Notifier):
                                                         allow_redirects=False, verify=True)
 
         if response is None:
-            logger.error("Tautulli Notifiers :: {name} notification to device {id} failed.".format(name=self.NAME, id=device_id))
+            logger.error("Tautulli Notifiers :: {name} notification to device {device} failed.".format(
+                name=self.NAME, device=device_label))
             if err_msg:
                 logger.error("Tautulli Notifiers :: {}".format(err_msg))
             return False
@@ -4117,9 +4120,9 @@ class TAUTULLIREMOTEAPP(Notifier):
             was_official = device['official'] == 1
             mobile_app.set_official_from_delivery(device, 0)
             log_dead_token = logger.error if was_official else logger.debug
-            log_dead_token("Tautulli Notifiers :: {name} notification failed: the push token for device '{device}' "
-                           "({id}) is no longer valid. Open Tautulli Remote on the device to register it "
-                           "again.".format(name=self.NAME, device=device_name, id=device_id))
+            log_dead_token("Tautulli Notifiers :: {name} notification to device {device} failed: the push token is "
+                           "no longer valid. Open Tautulli Remote on the device to register it again.".format(
+                               name=self.NAME, device=device_label))
 
         elif response.status_code == 429:
             # Only the daily fair use cap carries rate limit details, and unlike a
@@ -4130,23 +4133,26 @@ class TAUTULLIREMOTEAPP(Notifier):
                 rate_limits = {}
 
             if rate_limits:
-                logger.error("Tautulli Notifiers :: {name} notification failed: the daily notification limit "
-                             "for device '{device}' ({id}) has been reached. Further notifications to this "
-                             "device will fail until the limit resets at {reset}.".format(name=self.NAME, device=device_name,
-                                                                                          id=device_id,
-                                                                                          reset=rate_limits.get('resetsAt', 'the next reset')))
+                logger.error("Tautulli Notifiers :: {name} notification to device {device} failed: the daily "
+                             "notification limit has been reached. Further notifications to this device will "
+                             "fail until the limit resets at {reset}.".format(
+                                 name=self.NAME, device=device_label,
+                                 reset=rate_limits.get('resetsAt', 'the next reset')))
             else:
-                logger.error("Tautulli Notifiers :: {name} notification to device {id} failed: notifications "
-                             "are being rate limited. Retry after {retry} seconds.".format(name=self.NAME, id=device_id,
-                                                                                           retry=response.headers.get('Retry-After', 'unknown')))
+                logger.error("Tautulli Notifiers :: {name} notification to device {device} failed: notifications "
+                             "are being rate limited. Retry after {retry} seconds.".format(
+                                 name=self.NAME, device=device_label,
+                                 retry=response.headers.get('Retry-After', 'unknown')))
 
         elif response.status_code == 413:
-            logger.error("Tautulli Notifiers :: {name} notification to device {id} failed: the notification is "
-                         "too large to deliver. Shorten the notification text.".format(name=self.NAME, id=device_id))
+            logger.error("Tautulli Notifiers :: {name} notification to device {device} failed: the notification is "
+                         "too large to deliver. Shorten the notification text.".format(
+                             name=self.NAME, device=device_label))
 
         else:
-            logger.error("Tautulli Notifiers :: {name} notification failed for device {id}: the push relay "
-                         "returned status code {status}.".format(name=self.NAME, id=device_id, status=response.status_code))
+            logger.error("Tautulli Notifiers :: {name} notification to device {device} failed: the push relay "
+                         "returned status code {status}.".format(
+                             name=self.NAME, device=device_label, status=response.status_code))
 
         logger.debug("Tautulli Notifiers :: Request response: {}".format(request.server_message(response, True)))
         return False

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -4085,9 +4085,10 @@ class TAUTULLIREMOTEAPP(Notifier):
         device_id = mobile_app.relay_device_id(device['push_token'])
 
         logger.info("Tautulli Notifiers :: Sending {name} notification...".format(name=self.NAME))
+        # A 307 or 308 would re-post the push token to wherever Location points.
         response, err_msg, _ = request.request_response2(url, 'POST', auto_raise=False,
                                                         headers=headers, json=payload,
-                                                        timeout=self.TIMEOUT)
+                                                        timeout=self.TIMEOUT, allow_redirects=False)
 
         if response is None:
             logger.error("Tautulli Notifiers :: {name} notification to device {id} failed.".format(name=self.NAME, id=device_id))

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -4056,7 +4056,7 @@ class TAUTULLIREMOTEAPP(Notifier):
                 return None
 
             plaintext_data[key] = text[:low] + '...'
-            return "%s shortened from %s to %s characters" % (key, len(text), low)
+            return f"{key} shortened from {len(text)} to {low} characters"
 
         if encoded_length() <= budget:
             return True
@@ -4086,7 +4086,7 @@ class TAUTULLIREMOTEAPP(Notifier):
                    'platform': device['platform'] or 'android',
                    'data': data}
 
-        url = '%s/v1/notify' % plexpy.CONFIG.REMOTE_APP_PUSH_URL.rstrip('/')
+        url = f"{plexpy.CONFIG.REMOTE_APP_PUSH_URL.rstrip('/')}/v1/notify"
         # Newlines would let a device name forge additional log entries.
         device_name = ' '.join((device['friendly_name'] or device['device_name'] or '').split())
         device_id = mobile_app.relay_device_id(device['push_token'])

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 
 #  This file is part of Tautulli.
 #
@@ -4154,6 +4154,9 @@ class TAUTULLIREMOTEAPP(Notifier):
         url = '%s/v1/notify' % plexpy.CONFIG.REMOTE_APP_PUSH_URL.rstrip('/')
         # Newlines would let a device name forge additional log entries.
         device_name = ' '.join((device['friendly_name'] or device['device_name'] or '').split())
+        # The name is what the user recognises; the relay id is what matches this
+        # log against the relay's own records and the app's data dump page.
+        device_id = mobile_app.relay_device_id(device['push_token'])
 
         logger.info("Tautulli Notifiers :: Sending {name} notification...".format(name=self.NAME))
         # Without a timeout a stalled relay would hold one of the shared
@@ -4188,13 +4191,13 @@ class TAUTULLIREMOTEAPP(Notifier):
             mobile_app.set_official_from_delivery(device, 0)
             log_dead_token = logger.error if was_official else logger.debug
             log_dead_token("Tautulli Notifiers :: {name} notification failed: the push token for device '{device}' "
-                           "is no longer valid. Open Tautulli Remote on the device to register it again."
-                           .format(name=self.NAME, device=device_name))
+                           "({id}) is no longer valid. Open Tautulli Remote on the device to register it again."
+                           .format(name=self.NAME, device=device_name, id=device_id))
 
         elif response.status_code == 429:
             logger.error("Tautulli Notifiers :: {name} notification failed: the notification limit for device "
-                         "'{device}' has been reached. Retry after {retry} seconds."
-                         .format(name=self.NAME, device=device_name,
+                         "'{device}' ({id}) has been reached. Retry after {retry} seconds."
+                         .format(name=self.NAME, device=device_name, id=device_id,
                                  retry=response.headers.get('Retry-After', 'unknown')))
 
         elif response.status_code == 413:
@@ -4202,8 +4205,9 @@ class TAUTULLIREMOTEAPP(Notifier):
                          "deliver. Shorten the notification text.".format(name=self.NAME))
 
         else:
-            logger.error("Tautulli Notifiers :: {name} notification failed: the push relay returned status code "
-                         "{status}.".format(name=self.NAME, status=response.status_code))
+            logger.error("Tautulli Notifiers :: {name} notification failed for device {id}: the push relay "
+                         "returned status code {status}."
+                         .format(name=self.NAME, id=device_id, status=response.status_code))
 
         logger.debug("Tautulli Notifiers :: Request response: {}".format(request.server_message(response, True)))
         return False

--- a/plexpy/notifiers.py
+++ b/plexpy/notifiers.py
@@ -4081,7 +4081,7 @@ class TAUTULLIREMOTEAPP(Notifier):
                     % (self.NAME, ' and '.join(trimmed)))
         return True
 
-    def _send_via_relay(self, device, data, headers):
+    def _send_via_relay(self, device, data):
         payload = {'token': device['push_token'],
                    'platform': device['platform'] or 'android',
                    'data': data}
@@ -4094,8 +4094,7 @@ class TAUTULLIREMOTEAPP(Notifier):
         logger.info("Tautulli Notifiers :: Sending {name} notification...".format(name=self.NAME))
         # A 307 or 308 would re-post the push token to wherever Location points. The relay
         # is verified regardless of VERIFY_SSL_CERT, which is for the user's own server.
-        response, err_msg, _ = request.request_response2(url, 'POST', auto_raise=False,
-                                                        headers=headers, json=payload,
+        response, err_msg, _ = request.request_response2(url, 'POST', auto_raise=False, json=payload,
                                                         timeout=self.TIMEOUT,
                                                         allow_redirects=False, verify=True)
 
@@ -4220,11 +4219,10 @@ class TAUTULLIREMOTEAPP(Notifier):
 
         #logger.debug("Notification data: {}".format(data))
 
-        headers = {'Content-Type': 'application/json'}
-
         if via_relay:
-            return self._send_via_relay(device, data, headers)
+            return self._send_via_relay(device, data)
 
+        headers = {'Content-Type': 'application/json'}
         payload = {'app_id': mobile_app._ONESIGNAL_APP_ID,
                    'include_subscription_ids': [device['onesignal_id']],
                    'contents': {'en': 'Tautulli Notification'},

--- a/plexpy/request.py
+++ b/plexpy/request.py
@@ -144,7 +144,8 @@ def request_response2(url, method="get", auto_raise=True,
 
     # Disable verification of SSL certificates if requested. Note: this could
     # pose a security issue!
-    kwargs['verify'] = bool(plexpy.CONFIG.VERIFY_SSL_CERT)
+    # A caller can pass verify to require it for a single request regardless.
+    kwargs.setdefault('verify', bool(plexpy.CONFIG.VERIFY_SSL_CERT))
     if not kwargs['verify']:
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 


### PR DESCRIPTION
## Description

OneSignal's free plan drops to under 1,000 monthly active users on October 1st, 2026, with no
grandfathering. Tautulli Remote is well above that, so on that date notifications stop working for most
users of the app.

This adds a second delivery transport for the Tautulli Remote App notifier. It is a push relay that
forwards notifications to Firebase Cloud Messaging, and on to Apple's push service through FCM for iOS
devices. The relay is a Cloudflare Worker, open source under GPL v3 at
[Tautulli/Tautulli-Remote-Relay](https://github.com/Tautulli/Tautulli-Remote-Relay). The official instance runs at `relay.tautulliremote.com`.

Both transports run side by side. The choice is made per device, from the value stored in
`mobile_devices.push_token`, and not from any version comparison:

| `push_token` | Meaning | Transport |
| --- | --- | --- |
| `NULL` or empty | registered by an app version predating the relay | OneSignal, as before |
| `'push-disabled'` | new app, notifications turned off or token unavailable | neither, excluded from the device list |
| an FCM token | new app with notifications enabled | relay |

There is no flag day and no coordinated upgrade. A server running this can notify old and new app versions
at the same time, and users move over as they update the app. Removing the OneSignal path is a separate
change for after October 1st and is not part of this PR.

### What changed

<details>
<summary>New and changed functions</summary>

New

| | |
| --- | --- |
| `mobile_app.relay_device_id()` | SHA-256 prefix of a push token, for use wherever the token itself cannot be logged or shown |
| `mobile_app.validate_push_token()` | Checks a token against the relay: valid, dead, or indeterminate |
| `mobile_app.validates_remotely()` | Whether a device holds a credential worth a validation call |
| `mobile_app.set_official_from_delivery()` | Updates `official` from the result of a send |
| `mobile_app.revalidate_devices()` | Startup repair pass for unvalidated devices, on its own thread |
| `mobile_app._revalidate_devices()` | Its body: filters, paces, validates |
| `TAUTULLIREMOTEAPP._via_relay()` | Picks the transport for a device; shared by the sender and the config screen |
| `TAUTULLIREMOTEAPP._trim_to_relay_limit()` | Fits the payload to the relay's cap, or reports that it cannot |
| `TAUTULLIREMOTEAPP._send_via_relay()` | Posts to the relay and maps each response onto a log line |

Changed

| | |
| --- | --- |
| `mobile_app.set_official()` | Takes `push_token` and validates whichever credential was registered; an indeterminate result no longer clears a validated device |
| `mobile_app.add_mobile_device()` | Accepts and stores `push_token` |
| `mobile_app.get_mobile_device_config()` | Exposes `relay_device_id` to the device modal instead of the raw credential |
| `TAUTULLIREMOTEAPP.agent_notify()` | Selects a transport per device; drops a notification that cannot be trimmed to fit |
| `TAUTULLIREMOTEAPP.get_devices()` | Lists devices holding either credential, and excludes the disabled sentinel |
| `TAUTULLIREMOTEAPP._return_config_options()` | Names the delivery path, and keeps the OneSignal data collection notice for a device still delivered through it |
| `api2.register_device()` | Optional `push_token`, blacklisted from the logs on receipt |
| `request.request_response2()` | Defaults `verify` rather than assigning it, so a caller can require verification |
| `plexpy.upgrade()` and `initialize()` | Device revalidation moves off the one-shot upgrade flag and runs on every startup |

</details>

`plexpy/notifiers.py`

The Tautulli Remote App notifier picks a transport per device, using the relay when a push token is present
and is not the disabled sentinel. `_send_via_relay()` posts the existing notification envelope to the
configured relay URL and maps its responses onto separate log messages, so a dead token, a rate limit and
an oversized payload are each diagnosable instead of all reading "notification failed".

`get_devices()` now selects devices holding either credential, so relay-registered devices appear in the
notifier's device list. Devices carrying the disabled sentinel are excluded by the same query, which is why
they never reach a delivery attempt on either transport.

Relay payloads are capped at 3800 bytes, so `_trim_to_relay_limit()` shortens the notification before it is
sent. The budget is computed for the envelope actually being sent, since the encrypted form pays for base64
expansion and the unencrypted form does not. The body is shortened first and the subject only if emptying
the body was not enough, because the subject is the notification's headline. If the payload still does not
fit, the notification is dropped with an error rather than sent in a state the relay will refuse.

Three logging behaviours are worth calling out. A dead push token reports at error level once and at debug
afterwards: clearing the official flag only drops the device from the notifier configuration list, not from
an agent already saved against it, so a phone the user has stopped using would otherwise repeat the same
error on every notification. A rate limit says which of the two it is, because the relay attaches rate
limit details only for the daily fair use cap; a burst refusal clears in a minute, the cap does not clear
until it resets, and neither is retried. And every failure names the device the same way, as friendly name
and hashed id, since the id on its own is a token digest that nothing resolves to a phone.

The relay requests set `allow_redirects=False` and `verify=True`. The relay only ever answers 200, 410, 413,
429 or 5xx, so a redirect is always anomalous, and a 307 or 308 would re-send the push token to whatever
`Location` names, because the token travels in the request body rather than a header.

`plexpy/mobile_app.py`

`validate_push_token()` checks a token against the relay, mirroring the existing `validate_onesignal_id()`.
`set_official()` validates whichever credential the device actually registered with. An indeterminate
result, such as a rate limit or a relay or FCM outage, no longer clears a device that has previously
validated. Clearing it would drop the device out of the notifier's device list until the user re-registered
by hand, with nothing to indicate why.

`revalidate_devices()` repairs devices left unvalidated by an earlier outage. It runs on every startup, off
the startup thread, and skips devices that are already validated or that have no registration to check, so
a server where nothing needs repair does no work and logs nothing. It is paced at one device every two
seconds to stay inside the relay's per-IP limit on validation.

`relay_device_id()` returns the first sixteen characters of a push token's SHA-256, following the existing
`hash_pms_uuid()`. The push token is blacklisted from the logs, so without it the relay path had no way to
say which device a line referred to. The relay records the same value and Tautulli Remote displays it, so a
user's report, this log and the relay's own records can be lined up.

`plexpy/request.py`

`request_response2()` defaults `verify` instead of assigning it. It previously overwrote whatever a caller
passed, so a caller could not require verification for a single request. No existing call site passes
`verify`, so nothing else changes. The relay request uses it: `VERIFY_SSL_CERT` exists for the user's own
Plex server, and the relay is a third party host receiving a credential, so it should not follow that
setting.

`plexpy/__init__.py`

Adds `mobile_devices.push_token`, using the existing try-`SELECT` / except-`ALTER` dbcheck pattern.

Device revalidation moves out of `upgrade()` and into `initialize()`, unconditionally. It was gated behind
`CONFIG.UPGRADE_FLAG == 0`, a one-shot that has shipped set since v2.10.0, so on an existing install the
pass never ran and a device left unvalidated by an outage was never repaired. `UPGRADE_FLAG` now has no
readers; its config key is left in place.

`plexpy/api2.py`

`register_device` accepts an optional `push_token` parameter. Existing callers are unaffected. The token is
added to the logger blacklist on receipt, so it does not appear in Tautulli's logs.

`plexpy/config.py`

Adds `REMOTE_APP_PUSH_URL` under Advanced, defaulting to the official relay. Anyone running a fork of the
app with their own Firebase project can point their server at their own relay.

HTML

Three wording changes, all of them transport-neutral rather than relay-specific:

- `mobile_device_config.html`: the device field is labelled "Notification Device ID" instead of "OneSignal
  Device ID", and shows the hashed identifier described above, falling back to `onesignal_id` for devices
  that only have one. It replaces a field that displayed the raw credential, which an admin has no use for.
- `mobile_devices_table.html`: the failed-validation tooltip reads "Notification Registration Validation
  Failed" rather than naming OneSignal, since either credential can now fail to validate.
- `settings.html`: the "must not be blocked in Pi-hole" note names `relay.tautulliremote.com`, which is
  what someone configuring a DNS filter actually needs.

### What did not change

Notification encryption is untouched. The same AES-256-GCM envelope with a PBKDF2-derived key is used for
both transports. The relay forwards an opaque payload and cannot read it, in the same way OneSignal could
not.

The notifier's configuration and behaviour are unchanged for existing users. There are no settings to
migrate and nothing a server admin needs to do.

The OneSignal code path is untouched, and remains the default for every device already registered.

### Testing

Tautulli has no test suite, so all of this was run against throwaway harnesses rather than committed tests.

- A contract suite of 38 checks against the real `agent_notify()` and a real SQLite database, covering
  transport selection, the schema migration, `official` handling on each response code, and the encrypted
  payload decrypting with a PBKDF2 key derived from the device token.
- 14 end-to-end checks of a real Tautulli against a real relay over HTTP. These confirm that a failed
  delivery does not consume a device's quota, that an oversized payload is trimmed and accepted while an
  untrimmed one is refused, and that a validation failure during an outage returns indeterminate rather
  than invalid.
- Verified on an Android device end to end: registration, `official` set from a live relay validation, and
  an encrypted notification delivered, decrypted and displayed.
- Verified that the schema migration runs cleanly against an existing `tautulli.db`.

A later review pass over the branch produced the size-limit, redirect, certificate and logging changes
described above, and those were checked separately: the trim behaviour across both envelope shapes and the
refusal path, redirect refusal against a local 308 responder using the vendored `requests`, the `verify`
resolution for every combination of `VERIFY_SSL_CERT` and caller argument, the transport predicate against
every shape of device row `get_devices()` can return, and the notifier help text rendered for each
combination of cryptography availability and device transport.

### Issues Fixed or Closed

N/A

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated the docstring for new or existing methods