### PR TITLE
Fix remaining dashboard scroller clipping on Firefox 153

### DIFF
--- a/data/interfaces/default/css/tautulli.css
+++ b/data/interfaces/default/css/tautulli.css
@@ -997,6 +997,10 @@ a .users-poster-face:hover {
     flex-grow: 1;
     z-index: 1;
 }
+.dashboard-activity-info-scroller.scroll-wrapper > .scroll-content {
+    width: 100% !important;
+    max-height: 100% !important;
+}
 .dashboard-activity-info-scroller.scrollbar-macosx > .scroll-element.scroll-y {
     left: 10px;
 }
@@ -1442,6 +1446,7 @@ a .dashboard-activity-metadata-user-thumb:hover {
 }
 .dashboard-stats-info-scroller.scroll-wrapper > .scroll-content {
     width: 100% !important;
+    max-height: 100% !important;
 }
 .dashboard-stats-info-scroller.scrollbar-macosx > .scroll-element.scroll-y {
     left: 10px;


### PR DESCRIPTION
Follow-up to 61b2e7e4, which fixed the horizontal half of #2776. Two symptoms remain on Firefox 153.

`jquery.scrollbar` offsets `.scroll-content` by the measured native scrollbar size on
non-webkit browsers (`margin-right: -12px; margin-bottom: -12px`, plus
`max-height: 132px` for a 120px wrapper), expecting the native scrollbar to occupy that
overhang outside the wrapper's `overflow: hidden`. Firefox 153 honors the plugin's own
`::-webkit-scrollbar { width: 0; height: 0 }` as a hide-scrollbar shim, so the gutter is
0 and the overhang holds real content instead. Chrome never hit this because the plugin
short-circuits to `{width: 0, height: 0}` when `/webkit/i.test(navigator.userAgent)`.

`width: 100% !important` clamps the horizontal overhang, but `max-height: 132px` still
leaves 12px of vertical overhang, so the last row of a stats list is unreachable even at
maximum scroll. Measured on 2.17.2 and on nightly c6eceba9: all 15 stats tiles report
`scroll-content.offsetHeight - wrapper.clientHeight === 12`.

This adds `max-height: 100%` alongside `width: 100%`, and applies both to
`.dashboard-activity-info-scroller`, which has the same 12px horizontal overhang and was
not covered by 61b2e7e4. Percentages are safe on both because each wrapper has a fixed
pixel height (120px for stats, 225px for activity).

Verified on Firefox 153.0 and Chromium: zero horizontal and vertical overhang on all 16
scrollers, the phantom horizontal scrollbar is gone (the 12px overhang made the plugin
mark the x-axis scrollable while the native scroll range was 0, so the thumb rendered but
could not move), and vertical thumbs still appear on exactly the tiles with real overflow.

Related: #2762 targets the same clipping via row padding and `min-width` on the title
column, which addresses the layout symptom rather than the scroller overhang.

### Screenshots

latest (v2.17.2): counts column entirely clipped, last row cut
<img width="518" height="194" alt="Screenshot_20260814_181041" src="https://github.com/user-attachments/assets/007d1876-4557-4477-bb6e-4df44be2e5c6" />

nightly c6eceba9: counts restored by 61b2e7e4, last row still cut
<img width="518" height="194" alt="Screenshot_20260814_182447" src="https://github.com/user-attachments/assets/448c0f05-ef7d-4cba-aa53-2c545d4b7e27" />

this PR: both fixed, last row fully visible at max scroll
<img width="518" height="194" alt="Screenshot_20260814_180434" src="https://github.com/user-attachments/assets/0004b345-c00e-4c49-bb04-656857df95ad" />

### Issues Fixed or Closed

- Refs #2776

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code