### PR TITLE
Change PMS Image Proxy to Explicit

### DIFF
--- a/plexpy/webstart.py
+++ b/plexpy/webstart.py
@@ -253,6 +253,10 @@ def initialize(options):
             'tools.auth_basic.on': False,
             'tools.sessions.on': False,
         },
+        '/pms_image_proxy': {
+            # Slowest handler (Plex round-trip) but GET-only and never touches cherrypy.session, so nothing to lock.
+            'tools.sessions.locking': 'explicit',
+        },
         '/status': {
             'tools.auth_basic.on': False,
             'tools.sessions.on': True,


### PR DESCRIPTION
## Description

Tautulli's session tool defaults to 'early' locking, which holds a per-session lock across the entire request, and /pms_image_proxy is by far the slowest handler on the dashboard since it round-trips to Plex for a transcode. With a shared browser session this serializes every image request behind whichever one is already in flight, even though the browser opens six concurrent connections.

Overriding locking to 'explicit' for this endpoint alone removes that serialization, since the handler never reads or writes session data and has nothing to protect. Measured end to end this took a cold dashboard load from roughly 5.4s to 2s without changing session behavior anywhere else in the app.

### Screenshot

N/A

### Issues Fixed or Closed

N/A (no issue currently reported)

## Type of Change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Improves performance of Tautulli by not locking on image proxy requests.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated the docstring for new or existing methods
